### PR TITLE
Adding :flat_array notation to query_values

### DIFF
--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -3133,6 +3133,20 @@ describe Addressable::URI, "when parsed from " +
 end
 
 describe Addressable::URI, "when parsed from " +
+    "'?one=two&one=three'" do
+  before do
+    @uri = Addressable::URI.parse(
+      "?one=two&one=three"
+    )
+  end
+  
+  it "should have correct flat_array notation query values" do
+    @uri.query_values(:notation => :flat_array).should == 
+      [['one', 'two'], ['one', 'three']] 
+  end
+end
+
+describe Addressable::URI, "when parsed from " +
     "'?one[two][three][]=four&one[two][three][]=five'" do
   before do
     @uri = Addressable::URI.parse(
@@ -4183,6 +4197,13 @@ describe Addressable::URI, "when assigning query values" do
     @uri.query_values = {'ab' => 'c', :ab => 'a', :a => 'x'}
     @uri.query.should == "a=x&ab=a&ab=c"
   end
+  
+  it "should correctly assign " +
+      "[['b', 'c'], ['b', 'a'], ['a', 'a']]" do
+    @uri.query_values = [['b', 'c'], ['b', 'a'], ['a', 'a']]
+    @uri.query.should == "a=a&b=a&b=c"
+  end
+
 end
 
 describe Addressable::URI, "when assigning path values" do


### PR DESCRIPTION
For issue 21.

I took a stab at your suggested implementation.  The new notation is `:flat_array`.  Not sure that's the best name for it.  You can glean the behavior from the diff, but it basically adds support to `query_values` like so:

```
Addressable::URI.parse("?one=two&one=three").query_values(:notation => :flat_array)
#=> [['one', 'two'], ['one', 'three']]
```

And to `query_values=` to take in arrays.  `query_values=` already dealt with an array of arrays, so I just skipped the conversion if it's already an array.
