### PR TITLE
Recognize #! as part of the path instead of a fragment

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -85,7 +85,7 @@ module Addressable
 
       # This Regexp supplied as an example in RFC 3986, and it works great.
       uri_regex =
-        /^(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?$/
+        /^(([^:\/?#]+):)?(\/\/([^\/?#]*))?((?:(?:\#\!)|[^?#])*)(\?([^#]*))?(#(.*))?$/
       scan = uri.scan(uri_regex)
       fragments = scan[0]
       scheme = fragments[1]


### PR DESCRIPTION
The new #! urls break parsing, because the # in the #! is recognized as a fragment instead of part of the path, where it belongs.

I fixed the uri regex so it properly skips over those when parsing the path out. Actual fragments still work.

<pre>
>> ["https://twitter.com/#!/fields", "https://twitter.com/#!/fields#anchor", "https://twitter.com/!/fields#anchor", "https://twitter.com/#/fields", "https://twitter.com/fields#anchor", "http://gawker.com/#!5756377/craigslist-congressman-resigns#whatever"].each{|uri|
?>   puts "uri: #{uri}"
>>   uri_regex = /^(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?$/
>>   puts "old: #{uri.scan(uri_regex).inspect}"
>>   uri_regex = /^(([^:\/?#]+):)?(\/\/([^\/?#]*))?((?:(?:\#\!)|[^?#])*)(\?([^#]*))?(#(.*))?$/
>>   puts "new: #{uri.scan(uri_regex).inspect}"
>>   puts "---"
>> }
uri: https://twitter.com/#!/fields
old: [["https:", "https", "//twitter.com", "twitter.com", "/", nil, nil, "#!/fields", "!/fields"]]
new: [["https:", "https", "//twitter.com", "twitter.com", "/#!/fields", nil, nil, nil, nil]]

---
uri: https://twitter.com/#!/fields#anchor
old: [["https:", "https", "//twitter.com", "twitter.com", "/", nil, nil, "#!/fields#anchor", "!/fields#anchor"]]
new: [["https:", "https", "//twitter.com", "twitter.com", "/#!/fields", nil, nil, "#anchor", "anchor"]]

---
uri: https://twitter.com/!/fields#anchor
old: [["https:", "https", "//twitter.com", "twitter.com", "/!/fields", nil, nil, "#anchor", "anchor"]]
new: [["https:", "https", "//twitter.com", "twitter.com", "/!/fields", nil, nil, "#anchor", "anchor"]]

---
uri: https://twitter.com/#/fields
old: [["https:", "https", "//twitter.com", "twitter.com", "/", nil, nil, "#/fields", "/fields"]]
new: [["https:", "https", "//twitter.com", "twitter.com", "/", nil, nil, "#/fields", "/fields"]]

---
uri: https://twitter.com/fields#anchor
old: [["https:", "https", "//twitter.com", "twitter.com", "/fields", nil, nil, "#anchor", "anchor"]]
new: [["https:", "https", "//twitter.com", "twitter.com", "/fields", nil, nil, "#anchor", "anchor"]]

---
uri: http://gawker.com/#!5756377/craigslist-congressman-resigns#whatever
old: [["http:", "http", "//gawker.com", "gawker.com", "/", nil, nil, "#!5756377/craigslist-congressman-resigns#whatever", "!5756377/craigslist-congressman-resigns#whatever"]]
new: [["http:", "http", "//gawker.com", "gawker.com", "/#!5756377/craigslist-congressman-resigns", nil, nil, "#whatever", "whatever"]]

---
</pre>
