### PR TITLE
Query with ampersand bug

### DIFF
--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -2669,6 +2669,26 @@ describe Addressable::URI, "when parsed from " +
 end
 
 describe Addressable::URI, "when parsed from " +
+  "'http://example.com/search?q=Q%26A'" do
+
+  before do
+    @uri = Addressable::URI.parse("http://example.com/search?q=Q%26A")
+  end
+
+  it "should have a query of 'q=Q%26A'" do
+    @uri.query.should == "q=Q%26A"
+  end
+
+  it "should have query_values of {'q' => 'Q&A'}" do
+    @uri.query_values.should == { 'q' => 'Q&A' }
+  end
+
+  it "should normalize to the original uri (with the ampersand properly percent-encoded)" do
+    @uri.normalize.to_s.should == "http://example.com/search?q=Q%26A"
+  end
+end
+
+describe Addressable::URI, "when parsed from " +
     "'http://example.com/?q&&x=b'" do
   before do
     @uri = Addressable::URI.parse("http://example.com/?q&&x=b")


### PR DESCRIPTION
Here's a little snippet demonstrating the problem I'm seeing.  When a query value includes a percent-encoded ampersand (i.e. if a user searches at a site for "Q&A", resulting in "q=Q%26A"), addressable parsers it correctly.  However, when addressable normalizes it, and then re-parsers it, there's a bug.  I think the bug is in #normalize--I think it should normalize to `q=Q%26A`, not `q=Q&A`.

I've included a failing spec.

<pre>
require 'addressable/uri'
url = "http://www.example.com/search?q=Q%26A"

uri = Addressable::URI.parse(url)
puts uri.query_values # { 'q' => 'Q&A' }

uri = Addressable::URI.parse(uri.normalize.to_s)
puts uri.query_values # {"q"=>"Q", "A"=>true}
</pre>

