### PR TITLE
A freezed object can not use 'to_s' method

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -2063,6 +2063,11 @@ module Addressable
       return duplicated_uri
     end
 
+    def freeze
+      to_s
+      super
+    end
+
     ##
     # Omits components from a URI.
     #

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -166,6 +166,11 @@ describe Addressable::URI, "when created from nil components" do
     @uri.to_s.should == ""
   end
 
+  it "should be an empty uri if the object is frozen" do
+    @uri.freeze
+    @uri.to_s.should == ""
+  end
+
   it "should raise an error if the scheme is set to whitespace" do
     (lambda do
       @uri.scheme = "\t \n"


### PR DESCRIPTION
I confronted the title error when I use the gem of webmock.
I changed some codes. 
I hope it can be helpful for you.
