### PR TITLE
Strip whitespace when normalizing query string

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1355,8 +1355,8 @@ module Addressable
     # @return [String] The query component, normalized.
     def normalized_query
       @normalized_query ||= (begin
-        if self.query
-          (self.query.split("&", -1).map do |pair|
+        if self.query && self.query.strip != ''
+          (self.query.strip.split("&", -1).map do |pair|
             Addressable::URI.normalize_component(
               pair,
               Addressable::URI::CharacterClasses::QUERY.sub("\\&", "")

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -3490,6 +3490,20 @@ describe Addressable::URI, "when parsed from " +
 end
 
 describe Addressable::URI, "when parsed from " +
+  "'http://liveandcode.com/a/../?  '" do
+  before do
+    @uri = Addressable::URI.parse(
+      "http://liveandcode.com/a/../?  "
+    )
+  end
+
+  it "should normalize to 'http://liveandcode.com/'" do
+    @uri.normalize.should ==
+      Addressable::URI.parse('http://liveandcode.com/')
+  end
+end
+
+describe Addressable::URI, "when parsed from " +
     "'http://www.詹姆斯.com/'" do
   before do
     @uri = Addressable::URI.parse("http://www.詹姆斯.com/")


### PR DESCRIPTION
Addressable used to strip whitespace when normalizing query strings and seems to have stopped doing this in the newest version. This commit restores that functionality and adds an example for it to the spec.
