### PR TITLE
Fixing issues related URI#query_values=

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -2250,7 +2250,7 @@ module Addressable
     #
     # @return [String] an URI encoded component.
     def encode_uri_component(component)
-      component = component.to_s if component.kind_of?(Symbol)
+      component = component.to_s if component.kind_of?(Symbol) || component.kind_of?(Numeric)
       URI.encode_component(component, CharacterClasses::UNRESERVED)
     end
   end

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -4694,12 +4694,17 @@ describe Addressable::URI, "when assigning query values" do
     @uri.query.should == "a=a&b[c]&b[d]=d"
   end
 
+  it "should correctly assign {:a => 1, :b => 1.5}" do
+    @uri.query_values = { :a => 1, :b => 1.5 }
+    @uri.query.should == "a=1&b=1.5"
+  end
+
   it "should correctly assign " +
-  "{:z => '1', :f => ['2', {'999.1' => ['3','4']}, ['h', 'i']], :a => {:b => ['c', 'd'], :e => true, :y => '0.5'}}" do
+  "{:z => 1, :f => [2, {999.1 => [3,'4']}, ['h', 'i']], :a => {:b => ['c', 'd'], :e => true, :y => 0.5}}" do
     @uri.query_values = {
-      :z => '1',
-      :f => [ '2', {'999.1' => ['3','4']}, ['h', 'i'] ],
-      :a => { :b => ['c', 'd'], :e => true, :y => '0.5' }
+      :z => 1,
+      :f => [ 2, {999.1 => [3,'4']}, ['h', 'i'] ],
+      :a => { :b => ['c', 'd'], :e => true, :y => 0.5 }
     }
     @uri.query.should == "a[b][0]=c&a[b][1]=d&a[e]&a[y]=0.5&f[0]=2&f[1][999.1][0]=3&f[1][999.1][1]=4&f[2][0]=h&f[2][1]=i&z=1"
   end


### PR DESCRIPTION
Howdy,

  Per our conversation, here is a patch fixing both issues #36 and #37. I've also enable automatic conversion for Numeric types in URI#query_values=(via to_s). I'm not sure this is to spec.  My argument is that it's pretty annoying to have to convert the keys and values of a deeply nested hash to strings.  99% of the time to_s is what you want. So, might as well make it the default. 

  As for the implementation of the algorithm.  I've moved the query conversion code into a private recursive method (to_query). Logic seems to be a bit easier to follow this way. 

  Lastly, I've also added the corresponding specs for these new behaviors. Hope this is patch is useful.

Cheers,

_david
