### PR TITLE
Path components weren't being escaped before being used in a Regex.

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -2202,7 +2202,7 @@ module Addressable
         parent = normalized_path.match(NPATH2)
         if parent && ((parent[1] != PARENT1 && parent[1] != PARENT2) \
                       || (parent[2] != PARENT1 && parent[2] != PARENT2))
-          mod ||= normalized_path.gsub!(/\/#{parent[1]}\/\.\.\/|(\/#{parent[2]}\/\.\.$)/, SLASH)
+          mod ||= normalized_path.gsub!(/\/#{Regexp.escape(parent[1].to_s)}\/\.\.\/|(\/#{Regexp.escape(parent[2].to_s)}\/\.\.$)/, SLASH)
         end
 
         mod ||= normalized_path.gsub!(NPATH3, EMPTYSTR)

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -1844,6 +1844,82 @@ describe Addressable::URI, "when parsed from " +
 end
 
 describe Addressable::URI, "when parsed from " +
+    "'http://example.com/path(/..'" do
+  before do
+    @uri = Addressable::URI.parse("http://example.com/path(/..")
+  end
+
+  it "should have the correct port" do
+    @uri.inferred_port.should == 80
+  end
+
+  it "should not be considered to be in normal form" do
+    @uri.normalize.should_not be_eql(@uri)
+  end
+
+  it "should normalize to 'http://example.com/'" do
+    @uri.normalize.should === "http://example.com/"
+  end
+end
+
+describe Addressable::URI, "when parsed from " +
+    "'http://example.com/(path)/..'" do
+  before do
+    @uri = Addressable::URI.parse("http://example.com/(path)/..")
+  end
+
+  it "should have the correct port" do
+    @uri.inferred_port.should == 80
+  end
+
+  it "should not be considered to be in normal form" do
+    @uri.normalize.should_not be_eql(@uri)
+  end
+
+  it "should normalize to 'http://example.com/'" do
+    @uri.normalize.should === "http://example.com/"
+  end
+end
+
+describe Addressable::URI, "when parsed from " +
+    "'http://example.com/path(/../'" do
+  before do
+    @uri = Addressable::URI.parse("http://example.com/path(/../")
+  end
+
+  it "should have the correct port" do
+    @uri.inferred_port.should == 80
+  end
+
+  it "should not be considered to be in normal form" do
+    @uri.normalize.should_not be_eql(@uri)
+  end
+
+  it "should normalize to 'http://example.com/'" do
+    @uri.normalize.should === "http://example.com/"
+  end
+end
+
+describe Addressable::URI, "when parsed from " +
+    "'http://example.com/(path)/../'" do
+  before do
+    @uri = Addressable::URI.parse("http://example.com/(path)/../")
+  end
+
+  it "should have the correct port" do
+    @uri.inferred_port.should == 80
+  end
+
+  it "should not be considered to be in normal form" do
+    @uri.normalize.should_not be_eql(@uri)
+  end
+
+  it "should normalize to 'http://example.com/'" do
+    @uri.normalize.should === "http://example.com/"
+  end
+end
+
+describe Addressable::URI, "when parsed from " +
     "'http://example.com/path/to/resource/'" do
   before do
     @uri = Addressable::URI.parse("http://example.com/path/to/resource/")


### PR DESCRIPTION
I found that normalize_path would throw a RegexpError while trying to handle something like '/path(/..' .. It wasn't escaping components of the path before inserting it into another regex. As a result, any regexy syntax could influence the outcome of the normalization, either by causing an exception or causing the normalization to fail to return what was expected. 

If you take a look at my commit, you can see that I've added to the specs to demonstrate both the example I gave before, as well as normalizing something like '/(path)/..' .. I did each of these twice, with and without a trailing '/', in order to ensure that both paths in the regex were followed. 
