### PR TITLE
Merge support for query values into master.

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -719,6 +719,7 @@ module Addressable
         self.authority = options[:authority] if options[:authority]
         self.path = options[:path] if options[:path]
         self.query = options[:query] if options[:query]
+        self.query_values = options[:query_values] if options[:query_values]
         self.fragment = options[:fragment] if options[:fragment]
       end
     end


### PR DESCRIPTION
Hey,

The dm-rest-adapter expects the addressable initializer to accept query values. This did not seem to be supported by whats currently in master, though there is a writer method for it. Are we missing something or can this be merged into master? Appreciate your f/b

Thanks
