### PR TITLE
Update spec description to match what it does

### DIFF
--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -4769,7 +4769,7 @@ describe Addressable::URI, "when assigning query values" do
   end
 
   it "should correctly assign " +
-      "{:a => 'a', :b => {:c => true, :d => 'd'}, :e => []}" do
+      "{:a => 'a', :b => {:c => true, :d => 'd'}}" do
     @uri.query_values = {
       :a => 'a', :b => {:c => true, :d => 'd'}
     }


### PR DESCRIPTION
I happened to notice this spec's description says it assigns `:e => []` but it's not part of the assertion body.
