### PR TITLE
Make Addressable::URI.parse polymorphic

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -127,7 +127,7 @@ module Addressable
         port = nil
       end
 
-      return Addressable::URI.new(
+      return new(
         :scheme => scheme,
         :user => user,
         :password => password,


### PR DESCRIPTION
Addressable::URI.parse calls Addressable::URI.new explicitly, so one can't easily subclass from Addressable::URI, i.e.  if one creates his own subclass of Addressable::URI 

class MyAddressable < Addressable::URI  
...

with additional functionality,  MyAddressable.parse will still return an instance of Addressable::URI, making subclassing more difficult
