### PR TITLE
Fixing issue #76 on Windows by specifying that the marshalled data is to...

### DIFF
--- a/lib/addressable/idna/pure.rb
+++ b/lib/addressable/idna/pure.rb
@@ -319,7 +319,7 @@ module Addressable
 
     # This is a sparse Unicode table.  Codepoints without entries are
     # assumed to have the value: [0, 0, nil, nil, nil, nil, nil]
-    UNICODE_DATA = File.open(UNICODE_TABLE, "r") do |file|
+    UNICODE_DATA = File.open(UNICODE_TABLE, "rb") do |file|
       Marshal.load(file.read)
     end
 


### PR DESCRIPTION
... be read in binary format.

I have only tested this on Windows, and it fixes the latest version of addressable (2.3.1) to work on my machine. It definitely should be tested to make sure this doesn't break the code on other platforms, but I don't believe it should.
