### PR TITLE
Compatibility fix of URI#hostname and URI#hostname=

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1043,12 +1043,20 @@ module Addressable
     end
 
     ##
-    # @see Addressable::URI#host
-    alias_method :hostname, :host
+    # This method is same as URI::Generic#host except
+    # brackets for IPv6 (andn future IP) addresses are removed.
+    def hostname
+      v = self.host
+      /\A\[(.*)\]\z/ =~ v ? $1 : v
+    end
 
     ##
-    # @see Addressable::URI#host=
-    alias_method :hostname=, :host=
+    # This method is same as URI::Generic#host= except
+    # the argument can be bare IPv6 address.
+    def hostname=(v)
+      v = "[#{v}]" if /\A\[.*\]\z/ !~ v && /:/ =~ v
+      self.host = v
+    end
 
     ##
     # The authority component for this URI.

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -1257,6 +1257,28 @@ describe Addressable::URI, "when parsing IPv6 addresses" do
   end
 end
 
+describe Addressable::URI, "when parsing IPv6 address" do
+  subject { Addressable::URI.parse("http://[3ffe:1900:4545:3:200:f8ff:fe21:67cf]/") }
+  its(:host) { should == '[3ffe:1900:4545:3:200:f8ff:fe21:67cf]' }
+  its(:hostname) { should == '3ffe:1900:4545:3:200:f8ff:fe21:67cf' }
+end
+
+describe Addressable::URI, "when assigning IPv6 address" do
+  it "should allow to set bare IPv6 address as hostname" do
+    uri = Addressable::URI.parse("http://[::1]/")
+    uri.hostname = '3ffe:1900:4545:3:200:f8ff:fe21:67cf'
+    uri.to_s.should == 'http://[3ffe:1900:4545:3:200:f8ff:fe21:67cf]/'
+  end
+
+  it "should not allow to set bare IPv6 address as host" do
+    uri = Addressable::URI.parse("http://[::1]/")
+    pending "not checked"
+    (lambda do
+      uri.host = '3ffe:1900:4545:3:200:f8ff:fe21:67cf'
+    end).should raise_error(Addressable::URI::InvalidURIError)
+  end
+end
+
 describe Addressable::URI, "when parsing IPvFuture addresses" do
   it "should not raise an error for " +
       "'http://[v9.3ffe:1900:4545:3:200:f8ff:fe21:67cf]/'" do


### PR DESCRIPTION
These methods works differently with URI#host and URI#host= for IPv6
address.  Introduce method definitions from stdlib uri module for
compatibility.

Assigning bare IPv6 address via URI#host= should raise an exception but
this commit just adds a pending spec for compatibility concern.  Can we
raise an exception as well as stdlib uri module?
