### PR TITLE
Addressable::Template: Substitution with something that is not a Hash

### DIFF
--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -829,6 +829,7 @@ module Addressable
     # @return [Hash]
     #   A hash with stringified keys
     def normalize_keys(mapping)
+      return mapping unless mapping.respond_to?(:inject)
       return mapping.inject({}) do |accu, pair|
         name, value = pair
         if Symbol === name

--- a/spec/addressable/template_spec.rb
+++ b/spec/addressable/template_spec.rb
@@ -44,6 +44,12 @@ describe "Type conversion" do
   }
 end
 
+describe "Substituting from an optional block" do
+  sub = lambda { |x| "foo-#{x}" }
+
+  Addressable::Template.new("{bar}/{baz}").expand(sub).to_str.should == "foo-bar/foo-baz"
+end
+
 describe "Level 1:" do
   subject{
     {:var => "value", :hello => "Hello World!"}


### PR DESCRIPTION
I'm trying to replace my ad-hoc URI-Template parser with Addressable::Template.

However, I don't have the substitutions in Hash form. The current Template implementation assumes that substitutions are Enumerable (it calls `inject` on `mapping`)

Not calling inject makes it possible to pass a lambda (or anything else that responds to `[]` as a substitute:

```
describe "Substituting from an optional block" do
  sub = lambda { |x| "foo-#{x}" }
  Addressable::Template.new("{bar}/{baz}").expand(sub).to_str.should == "foo-bar/foo-baz"
end
```

Ideally I'd like to change expand to take a block like so:

```
template.expand { |field| "foo-#{field}" }
```

but I'd like to hear what you think about changing the API in that way.
