### PR TITLE
Enable native IDN support in Ruby 1.9.

### DIFF
--- a/lib/addressable/idna/native.rb
+++ b/lib/addressable/idna/native.rb
@@ -16,7 +16,12 @@
 #++
 
 
-require "idn_one_nine"
+# Accomodate Ruby 1.9 (idn_one_nine gem) and Ruby 1.8 (idn gem).
+begin
+  require "idn_one_nine"
+rescue LoadError
+  require "idn"
+end
 
 module Addressable
   module IDNA


### PR DESCRIPTION
I ported the old [idn](http://rubygems.org/gems/idn) gem to Ruby 1.9 in the [idn_one_nine](https://github.com/bradcater/idn_one_nine) gem. I haven't pushed it to RubyGems as a "proper" gem yet, as it's still lacking documentation. Since it's purely a port to be compatible with the 1.9 API versus the old 1.8 API (and porting the tests from Test::Unit to RSpec), the interfaces should "just work."

Would you be interested in incorporating the [idn_one_nine](https://github.com/bradcater/idn_one_nine) gem in addressable if I get it packaged up and on the usual gem hosts? If so, I'll get that done.
