### PR TITLE
gracefully handle missing coveralls gem

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,6 @@
-require 'coveralls'
-Coveralls.wear!
+begin
+  require 'coveralls'
+  Coveralls.wear!
+rescue LoadError
+  warn "warning: coveralls gem not found; skipping Coveralls"
+end


### PR DESCRIPTION
If we do not have coveralls installed, we should be able to continue with the rest of the test suite.
