### PR TITLE
Support standard URI classes in heuristically_parse

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -162,6 +162,15 @@ module Addressable
       return nil unless uri
       # If a URI object is passed, just return itself.
       return uri.dup if uri.kind_of?(self)
+
+      # If a URI object of the Ruby standard library variety is passed,
+      # convert it to a string, then parse the string.
+      # We do the check this way because we don't want to accidentally
+      # cause a missing constant exception to be thrown.
+      if uri.class.name =~ /^URI\b/
+        uri = uri.to_s
+      end
+
       if !uri.respond_to?(:to_str)
         raise TypeError, "Can't convert #{uri.class} into String."
       end

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -17,6 +17,7 @@
 require "spec_helper"
 
 require "addressable/uri"
+require "uri"
 
 if !"".respond_to?("force_encoding")
   class String
@@ -5675,6 +5676,18 @@ describe Addressable::URI, "when given the input " +
   it "should heuristically parse to 'feed:http://example.com'" do
     @uri = Addressable::URI.heuristic_parse(@input)
     @uri.to_s.should == "feed:http://example.com"
+  end
+end
+
+describe Addressable::URI, "when given the input " +
+    "::URI.parse('http://example.com')" do
+  before do
+    @input = ::URI.parse('http://example.com')
+  end
+
+  it "should heuristically parse to 'http://example.com'" do
+    @uri = Addressable::URI.heuristic_parse(@input)
+    @uri.to_s.should == "http://example.com"
   end
 end
 


### PR DESCRIPTION
Like `Addressable::URI.parse`, `Addressable::URI.heuristic_parse` should
also support standard URI classes.
