### PR TITLE
Fix character class bug/warnings

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -505,7 +505,7 @@ module Addressable
       end
       if character_class.kind_of?(String)
         leave_re = if leave_encoded.length > 0
-          character_class << '%'
+          character_class = "#{character_class}%" unless character_class.include?('%')
 
           "|%(?!#{leave_encoded.chars.map do |char|
             seq = char.unpack('C*').map { |c| '%02x' % c }.join

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -5372,6 +5372,16 @@ describe Addressable::URI, "when normalizing a string but leaving some character
     Addressable::URI.normalize_component("%58X%59Y%5AZ", "0-9a-zXY", "Y").should ==
       "XX%59Y%5A%5A"
   end
+
+  it "should not modify the character class" do
+    character_class = "0-9a-zXY"
+
+    character_class_copy = character_class.dup
+
+    Addressable::URI.normalize_component("%58X%59Y%5AZ", character_class, "Y")
+
+    character_class.should == character_class_copy
+  end
 end
 
 describe Addressable::URI, "when encoding a string with existing encodings to upcase" do


### PR DESCRIPTION
Starting at the top, here is a relatively minimal example which demonstrates the issue:

``` ruby
require 'addressable/uri'

uri = Addressable::URI.parse('http://httpbin.org/get?a=1&b=2')
uri.normalize
```

Running that with `-W2` results in 2 "character class has duplicated range" warnings. Remove one of the query string parameters and the warnings disappear.

Looking at the code, this is because `normalized_query` calls `Addressable::URI.normalize_component` with a third argument (uri.rb#L1468). This triggers a conditional which results in a destructive change to the character_class argument, uri.rb#L508. The following lower level example shows the duplicated percent character:

``` ruby
require 'addressable/uri'

character_class = Addressable::URI::CharacterClasses::QUERY

Addressable::URI.normalize_component('xxx', character_class, '+')
Addressable::URI.normalize_component('xxx', character_class, '+')

p character_class
```

It doesn't make much sense to spec that this shouldn't happen, and there might be a better fix, but this hopefully is sufficient to highlight/demonstrate the problem.
