### PR TITLE
Implement #eql? for Addressable::Template

### DIFF
--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -251,6 +251,20 @@ module Addressable
     end
 
     ##
+    # Returns <code>true</code> if the Template objects are equal. This method
+    # does NOT normalize either Template before doing the comparison.
+    #
+    # @param [Object] template The Template to compare.
+    #
+    # @return [TrueClass, FalseClass]
+    #   <code>true</code> if the Templates are equivalent, <code>false</code>
+    #   otherwise.
+    def eql?(template)
+      return false unless template.kind_of?(Template)
+      return self.pattern == template.pattern
+    end
+
+    ##
     # Extracts a mapping from the URI using a URI Template pattern.
     #
     # @param [Addressable::URI, #to_str] uri

--- a/spec/addressable/template_spec.rb
+++ b/spec/addressable/template_spec.rb
@@ -32,6 +32,27 @@ shared_examples_for 'expands' do |tests|
   end
 end
 
+describe "eql?" do
+  let(:template) { Addressable::Template.new('https://www.example.com/{foo}') }
+  it 'is equal when the pattern matches' do
+    other_template = Addressable::Template.new('https://www.example.com/{foo}')
+    expect(template).to be_eql(other_template)
+    expect(other_template).to be_eql(template)
+  end
+  it 'is not equal when the pattern differs' do
+    other_template = Addressable::Template.new('https://www.example.com/{bar}')
+    expect(template).to_not be_eql(other_template)
+    expect(other_template).to_not be_eql(template)
+  end
+  it 'is not equal to non-templates' do
+    uri = 'https://www.example.com/foo/bar'
+    addressable_template = Addressable::Template.new uri
+    addressable_uri = Addressable::URI.parse uri
+    expect(addressable_template).to_not be_eql(addressable_uri)
+    expect(addressable_uri).to_not be_eql(addressable_template)
+  end
+end
+
 describe "Type conversion" do
   subject{
     {:var => true, :hello => 1234, :nothing => nil, :sym => :symbolic}


### PR DESCRIPTION
Almost the same as Addressable::URI, but it is based on the pattern instead of to_s.

This is false without implementing eql?:

``` ruby
Addressable::Template.new('https://www.example.com').eql? Addressable::Template.new('https://www.example.com')
```
