### PR TITLE
Convert specs to RSpec 3.0 with Transpec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+gemspec
+
 group :development do
   gem 'launchy'
   gem 'yard'
@@ -10,7 +12,7 @@ end
 group :test, :development do
   gem 'rake', '>= 0.7.3'
   gem 'rspec', '>= 2.9.0'
-  gem 'coveralls', :require => false
+  gem 'coveralls', :require => false, :platforms => [:ruby_19, :ruby_20, :ruby_21, :rbx, :jruby]
 end
 
 gem 'idn', :platform => :mri_18
@@ -24,5 +26,3 @@ platforms :rbx do
   gem 'rubysl', '~> 2.0'
   gem 'rubinius-coverage'
 end
-
-gemspec

--- a/spec/addressable/idna_spec.rb
+++ b/spec/addressable/idna_spec.rb
@@ -23,34 +23,34 @@ require "addressable/idna"
 
 shared_examples_for "converting from unicode to ASCII" do
   it "should convert 'www.google.com' correctly" do
-    Addressable::IDNA.to_ascii("www.google.com").should == "www.google.com"
+    expect(Addressable::IDNA.to_ascii("www.google.com")).to eq("www.google.com")
   end
 
   it "should convert 'www.詹姆斯.com' correctly" do
-    Addressable::IDNA.to_ascii(
+    expect(Addressable::IDNA.to_ascii(
       "www.詹姆斯.com"
-    ).should == "www.xn--8ws00zhy3a.com"
+    )).to eq("www.xn--8ws00zhy3a.com")
   end
 
   it "should convert 'www.Iñtërnâtiônàlizætiøn.com' correctly" do
     "www.Iñtërnâtiônàlizætiøn.com"
-    Addressable::IDNA.to_ascii(
+    expect(Addressable::IDNA.to_ascii(
       "www.I\xC3\xB1t\xC3\xABrn\xC3\xA2ti\xC3\xB4" +
       "n\xC3\xA0liz\xC3\xA6ti\xC3\xB8n.com"
-    ).should == "www.xn--itrntinliztin-vdb0a5exd8ewcye.com"
+    )).to eq("www.xn--itrntinliztin-vdb0a5exd8ewcye.com")
   end
 
   it "should convert 'www.Iñtërnâtiônàlizætiøn.com' correctly" do
-    Addressable::IDNA.to_ascii(
+    expect(Addressable::IDNA.to_ascii(
       "www.In\xCC\x83te\xCC\x88rna\xCC\x82tio\xCC\x82n" +
       "a\xCC\x80liz\xC3\xA6ti\xC3\xB8n.com"
-    ).should == "www.xn--itrntinliztin-vdb0a5exd8ewcye.com"
+    )).to eq("www.xn--itrntinliztin-vdb0a5exd8ewcye.com")
   end
 
   it "should convert " +
       "'www.ほんとうにながいわけのわからないどめいんめいのらべるまだながくしないとたりない.w3.mag.keio.ac.jp' " +
       "correctly" do
-    Addressable::IDNA.to_ascii(
+    expect(Addressable::IDNA.to_ascii(
       "www.\343\201\273\343\202\223\343\201\250\343\201\206\343\201\253\343" +
       "\201\252\343\201\214\343\201\204\343\202\217\343\201\221\343\201\256" +
       "\343\202\217\343\201\213\343\202\211\343\201\252\343\201\204\343\201" +
@@ -59,15 +59,16 @@ shared_examples_for "converting from unicode to ASCII" do
       "\343\201\252\343\201\214\343\201\217\343\201\227\343\201\252\343\201" +
       "\204\343\201\250\343\201\237\343\202\212\343\201\252\343\201\204." +
       "w3.mag.keio.ac.jp"
-    ).should ==
+    )).to eq(
       "www.xn--n8jaaaaai5bhf7as8fsfk3jnknefdde3" +
       "fg11amb5gzdb4wi9bya3kc6lra.w3.mag.keio.ac.jp"
+    )
   end
 
   it "should convert " +
       "'www.ほんとうにながいわけのわからないどめいんめいのらべるまだながくしないとたりない.w3.mag.keio.ac.jp' " +
       "correctly" do
-    Addressable::IDNA.to_ascii(
+    expect(Addressable::IDNA.to_ascii(
       "www.\343\201\273\343\202\223\343\201\250\343\201\206\343\201\253\343" +
       "\201\252\343\201\213\343\202\231\343\201\204\343\202\217\343\201\221" +
       "\343\201\256\343\202\217\343\201\213\343\202\211\343\201\252\343\201" +
@@ -77,133 +78,136 @@ shared_examples_for "converting from unicode to ASCII" do
       "\213\343\202\231\343\201\217\343\201\227\343\201\252\343\201\204\343" +
       "\201\250\343\201\237\343\202\212\343\201\252\343\201\204." +
       "w3.mag.keio.ac.jp"
-    ).should ==
+    )).to eq(
       "www.xn--n8jaaaaai5bhf7as8fsfk3jnknefdde3" +
       "fg11amb5gzdb4wi9bya3kc6lra.w3.mag.keio.ac.jp"
+    )
   end
 
   it "should convert '点心和烤鸭.w3.mag.keio.ac.jp' correctly" do
-    Addressable::IDNA.to_ascii(
+    expect(Addressable::IDNA.to_ascii(
       "点心和烤鸭.w3.mag.keio.ac.jp"
-    ).should == "xn--0trv4xfvn8el34t.w3.mag.keio.ac.jp"
+    )).to eq("xn--0trv4xfvn8el34t.w3.mag.keio.ac.jp")
   end
 
   it "should convert '가각갂갃간갅갆갇갈갉힢힣.com' correctly" do
-    Addressable::IDNA.to_ascii(
+    expect(Addressable::IDNA.to_ascii(
       "가각갂갃간갅갆갇갈갉힢힣.com"
-    ).should == "xn--o39acdefghijk5883jma.com"
+    )).to eq("xn--o39acdefghijk5883jma.com")
   end
 
   it "should convert " +
       "'\347\242\274\346\250\231\346\272\226\350" +
       "\220\254\345\234\213\347\242\274.com' correctly" do
-    Addressable::IDNA.to_ascii(
+    expect(Addressable::IDNA.to_ascii(
       "\347\242\274\346\250\231\346\272\226\350" +
       "\220\254\345\234\213\347\242\274.com"
-    ).should == "xn--9cs565brid46mda086o.com"
+    )).to eq("xn--9cs565brid46mda086o.com")
   end
 
   it "should convert 'ﾘ宠퐱〹.com' correctly" do
-    Addressable::IDNA.to_ascii(
+    expect(Addressable::IDNA.to_ascii(
       "\357\276\230\345\256\240\355\220\261\343\200\271.com"
-    ).should == "xn--eek174hoxfpr4k.com"
+    )).to eq("xn--eek174hoxfpr4k.com")
   end
 
   it "should convert 'リ宠퐱卄.com' correctly" do
-    Addressable::IDNA.to_ascii(
+    expect(Addressable::IDNA.to_ascii(
       "\343\203\252\345\256\240\355\220\261\345\215\204.com"
-    ).should == "xn--eek174hoxfpr4k.com"
+    )).to eq("xn--eek174hoxfpr4k.com")
   end
 
   it "should convert 'ᆵ' correctly" do
-    Addressable::IDNA.to_ascii(
+    expect(Addressable::IDNA.to_ascii(
       "\341\206\265"
-    ).should == "xn--4ud"
+    )).to eq("xn--4ud")
   end
 
   it "should convert 'ﾯ' correctly" do
-    Addressable::IDNA.to_ascii(
+    expect(Addressable::IDNA.to_ascii(
       "\357\276\257"
-    ).should == "xn--4ud"
+    )).to eq("xn--4ud")
   end
 
   it "should handle two adjacent '.'s correctly" do
-    Addressable::IDNA.to_ascii(
+    expect(Addressable::IDNA.to_ascii(
       "example..host"
-    ).should == "example..host"
+    )).to eq("example..host")
   end
 end
 
 shared_examples_for "converting from ASCII to unicode" do
   it "should convert 'www.google.com' correctly" do
-    Addressable::IDNA.to_unicode("www.google.com").should == "www.google.com"
+    expect(Addressable::IDNA.to_unicode("www.google.com")).to eq("www.google.com")
   end
 
   it "should convert 'www.詹姆斯.com' correctly" do
-    Addressable::IDNA.to_unicode(
+    expect(Addressable::IDNA.to_unicode(
       "www.xn--8ws00zhy3a.com"
-    ).should == "www.詹姆斯.com"
+    )).to eq("www.詹姆斯.com")
   end
 
   it "should convert 'www.iñtërnâtiônàlizætiøn.com' correctly" do
-    Addressable::IDNA.to_unicode(
+    expect(Addressable::IDNA.to_unicode(
       "www.xn--itrntinliztin-vdb0a5exd8ewcye.com"
-    ).should == "www.iñtërnâtiônàlizætiøn.com"
+    )).to eq("www.iñtërnâtiônàlizætiøn.com")
   end
 
   it "should convert " +
       "'www.ほんとうにながいわけのわからないどめいんめいのらべるまだながくしないとたりない.w3.mag.keio.ac.jp' " +
       "correctly" do
-    Addressable::IDNA.to_unicode(
+    expect(Addressable::IDNA.to_unicode(
       "www.xn--n8jaaaaai5bhf7as8fsfk3jnknefdde3" +
       "fg11amb5gzdb4wi9bya3kc6lra.w3.mag.keio.ac.jp"
-    ).should ==
+    )).to eq(
       "www.ほんとうにながいわけのわからないどめいんめいのらべるまだながくしないとたりない.w3.mag.keio.ac.jp"
+    )
   end
 
   it "should convert '点心和烤鸭.w3.mag.keio.ac.jp' correctly" do
-    Addressable::IDNA.to_unicode(
+    expect(Addressable::IDNA.to_unicode(
       "xn--0trv4xfvn8el34t.w3.mag.keio.ac.jp"
-    ).should == "点心和烤鸭.w3.mag.keio.ac.jp"
+    )).to eq("点心和烤鸭.w3.mag.keio.ac.jp")
   end
 
   it "should convert '가각갂갃간갅갆갇갈갉힢힣.com' correctly" do
-    Addressable::IDNA.to_unicode(
+    expect(Addressable::IDNA.to_unicode(
       "xn--o39acdefghijk5883jma.com"
-    ).should == "가각갂갃간갅갆갇갈갉힢힣.com"
+    )).to eq("가각갂갃간갅갆갇갈갉힢힣.com")
   end
 
   it "should convert " +
       "'\347\242\274\346\250\231\346\272\226\350" +
       "\220\254\345\234\213\347\242\274.com' correctly" do
-    Addressable::IDNA.to_unicode(
+    expect(Addressable::IDNA.to_unicode(
       "xn--9cs565brid46mda086o.com"
-    ).should ==
+    )).to eq(
       "\347\242\274\346\250\231\346\272\226\350" +
       "\220\254\345\234\213\347\242\274.com"
+    )
   end
 
   it "should convert 'リ宠퐱卄.com' correctly" do
-    Addressable::IDNA.to_unicode(
+    expect(Addressable::IDNA.to_unicode(
       "xn--eek174hoxfpr4k.com"
-    ).should == "\343\203\252\345\256\240\355\220\261\345\215\204.com"
+    )).to eq("\343\203\252\345\256\240\355\220\261\345\215\204.com")
   end
 
   it "should convert 'ﾯ' correctly" do
-    Addressable::IDNA.to_unicode(
+    expect(Addressable::IDNA.to_unicode(
       "xn--4ud"
-    ).should == "\341\206\265"
+    )).to eq("\341\206\265")
   end
 
   it "should handle two adjacent '.'s correctly" do
-    Addressable::IDNA.to_unicode(
+    expect(Addressable::IDNA.to_unicode(
       "example..host"
-    ).should == "example..host"
+    )).to eq("example..host")
   end
 
   it "should normalize 'string' correctly" do
-    Addressable::IDNA.unicode_normalize_kc(:'string').should == "string"
-    Addressable::IDNA.unicode_normalize_kc("string").should == "string"
+    expect(Addressable::IDNA.unicode_normalize_kc(:'string')).to eq("string")
+    expect(Addressable::IDNA.unicode_normalize_kc("string")).to eq("string")
   end
 end
 

--- a/spec/addressable/net_http_compat_spec.rb
+++ b/spec/addressable/net_http_compat_spec.rb
@@ -23,6 +23,6 @@ describe Net::HTTP do
   it "should be compatible with Addressable" do
     response_body =
       Net::HTTP.get(Addressable::URI.parse('http://www.google.com/'))
-    response_body.should_not be_nil
+    expect(response_body).not_to be_nil
   end
 end

--- a/spec/addressable/template_spec.rb
+++ b/spec/addressable/template_spec.rb
@@ -24,9 +24,9 @@ shared_examples_for 'expands' do |tests|
     it "#{template} to #{exp}" do
       tmpl = Addressable::Template.new(template).expand(subject)
       if expansion.is_a?(Array)
-        expansion.any?{|i| i == tmpl.to_str}.should be_true
+        expect(expansion.any?{|i| i == tmpl.to_str}).to be_truthy
       else
-        tmpl.to_str.should == expansion
+        expect(tmpl.to_str).to eq(expansion)
       end
     end
   end
@@ -57,20 +57,20 @@ describe "==" do
   let(:template) { Addressable::Template.new('https://www.example.com/{foo}') }
   it 'is equal when the pattern matches' do
     other_template = Addressable::Template.new('https://www.example.com/{foo}')
-    expect(template).should == other_template
-    expect(other_template).should == template
+    expect(template).to eq(other_template)
+    expect(other_template).to eq(template)
   end
   it 'is not equal when the pattern differs' do
     other_template = Addressable::Template.new('https://www.example.com/{bar}')
-    expect(template).should_not == other_template
-    expect(other_template).should_not == template
+    expect(template).not_to eq(other_template)
+    expect(other_template).not_to eq(template)
   end
   it 'is not equal to non-templates' do
     uri = 'https://www.example.com/foo/bar'
     addressable_template = Addressable::Template.new uri
     addressable_uri = Addressable::URI.parse uri
-    expect(addressable_template).should_not == addressable_uri
-    expect(addressable_uri).should_not == addressable_template
+    expect(addressable_template).not_to eq(addressable_uri)
+    expect(addressable_uri).not_to eq(addressable_template)
   end
 end
 
@@ -753,8 +753,16 @@ describe Addressable::Template do
           "http://example.com/search/{query}/"
         ).match(uri, ExampleTwoProcessor)
       }
-      its(:variables){ should == ["query"] }
-      its(:captures){ should == ["an example search query"] }
+
+      describe '#variables' do
+        subject { super().variables }
+        it { is_expected.to eq(["query"]) }
+      end
+
+      describe '#captures' do
+        subject { super().captures }
+        it { is_expected.to eq(["an example search query"]) }
+      end
     end
 
     context "second uri with ExampleTwoProcessor" do
@@ -763,8 +771,16 @@ describe Addressable::Template do
           "http://example.com/{first}/{+second}/"
         ).match(uri2, ExampleTwoProcessor)
       }
-      its(:variables){ should == ["first", "second"] }
-      its(:captures){ should == ["a", "b/c"] }
+
+      describe '#variables' do
+        subject { super().variables }
+        it { is_expected.to eq(["first", "second"]) }
+      end
+
+      describe '#captures' do
+        subject { super().captures }
+        it { is_expected.to eq(["a", "b/c"]) }
+      end
     end
 
     context "second uri with DumbProcessor" do
@@ -773,8 +789,16 @@ describe Addressable::Template do
           "http://example.com/{first}/{+second}/"
         ).match(uri2, DumbProcessor)
       }
-      its(:variables){ should == ["first", "second"] }
-      its(:captures){ should == ["a", "b/c"] }
+
+      describe '#variables' do
+        subject { super().variables }
+        it { is_expected.to eq(["first", "second"]) }
+      end
+
+      describe '#captures' do
+        subject { super().captures }
+        it { is_expected.to eq(["a", "b/c"]) }
+      end
     end
 
     context "second uri" do
@@ -783,8 +807,16 @@ describe Addressable::Template do
           "http://example.com/{first}{/second*}/"
         ).match(uri2)
       }
-      its(:variables){ should == ["first", "second"] }
-      its(:captures){ should == ["a", ["b","c"]] }
+
+      describe '#variables' do
+        subject { super().variables }
+        it { is_expected.to eq(["first", "second"]) }
+      end
+
+      describe '#captures' do
+        subject { super().captures }
+        it { is_expected.to eq(["a", ["b","c"]]) }
+      end
     end
     context "third uri" do
       subject {
@@ -792,9 +824,17 @@ describe Addressable::Template do
           "http://example.com/{;hash*,first}"
         ).match(uri3)
       }
-      its(:variables){ should == ["hash", "first"] }
-      its(:captures){ should == [
-        {"a" => "1", "b" => "2", "c" => "3", "first" => "foo"}, nil] }
+
+      describe '#variables' do
+        subject { super().variables }
+        it { is_expected.to eq(["hash", "first"]) }
+      end
+
+      describe '#captures' do
+        subject { super().captures }
+        it { is_expected.to eq([
+        {"a" => "1", "b" => "2", "c" => "3", "first" => "foo"}, nil]) }
+      end
     end
     # Note that this expansion is impossible to revert deterministically - the
     # * operator means first could have been a key of hash or a separate key.
@@ -805,9 +845,17 @@ describe Addressable::Template do
           "http://example.com/{?hash*,first}"
         ).match(uri4)
       }
-      its(:variables){ should == ["hash", "first"] }
-      its(:captures){ should == [
-        {"a" => "1", "b" => "2", "c" => "3", "first"=> "foo"}, nil] }
+
+      describe '#variables' do
+        subject { super().variables }
+        it { is_expected.to eq(["hash", "first"]) }
+      end
+
+      describe '#captures' do
+        subject { super().captures }
+        it { is_expected.to eq([
+        {"a" => "1", "b" => "2", "c" => "3", "first"=> "foo"}, nil]) }
+      end
     end
     context "fifth uri" do
       subject {
@@ -815,8 +863,16 @@ describe Addressable::Template do
           "http://example.com/{path}{?hash*,first}"
         ).match(uri5)
       }
-      its(:variables){ should == ["path", "hash", "first"] }
-      its(:captures){ should == ["foo", nil, nil] }
+
+      describe '#variables' do
+        subject { super().variables }
+        it { is_expected.to eq(["path", "hash", "first"]) }
+      end
+
+      describe '#captures' do
+        subject { super().captures }
+        it { is_expected.to eq(["foo", nil, nil]) }
+      end
     end
   end
   describe "extract" do
@@ -828,24 +884,24 @@ describe Addressable::Template do
     let(:uri){ "http://example.com/a/b/c/?one=1&two=2#foo" }
     let(:uri2){ "http://example.com/a/b/c/#foo" }
     it "should be able to extract with queries" do
-      template.extract(uri).should == {
+      expect(template.extract(uri)).to eq({
         "host" => "example.com",
         "segments" => %w(a b c),
         "one" => "1",
         "bogus" => nil,
         "two" => "2",
         "fragment" => "foo"
-      }
+      })
     end
     it "should be able to extract without queries" do
-      template.extract(uri2).should == {
+      expect(template.extract(uri2)).to eq({
         "host" => "example.com",
         "segments" => %w(a b c),
         "one" => nil,
         "bogus" => nil,
         "two" => nil,
         "fragment" => "foo"
-      }
+      })
     end
 
     context "issue #137" do
@@ -853,30 +909,30 @@ describe Addressable::Template do
 
       it "can match empty" do
         data = subject.extract("/path")
-        data["page"].should == nil
-        data["per_page"].should == nil
-        data.keys.sort.should == ['page', 'per_page']
+        expect(data["page"]).to eq(nil)
+        expect(data["per_page"]).to eq(nil)
+        expect(data.keys.sort).to eq(['page', 'per_page'])
       end
 
       it "can match first var" do
         data = subject.extract("/path?page=1")
-        data["page"].should == "1"
-        data["per_page"].should == nil
-        data.keys.sort.should == ['page', 'per_page']
+        expect(data["page"]).to eq("1")
+        expect(data["per_page"]).to eq(nil)
+        expect(data.keys.sort).to eq(['page', 'per_page'])
       end
 
       it "can match second var" do
         data = subject.extract("/path?per_page=1")
-        data["page"].should == nil
-        data["per_page"].should == "1"
-        data.keys.sort.should == ['page', 'per_page']
+        expect(data["page"]).to eq(nil)
+        expect(data["per_page"]).to eq("1")
+        expect(data.keys.sort).to eq(['page', 'per_page'])
       end
 
       it "can match both vars" do
         data = subject.extract("/path?page=2&per_page=1")
-        data["page"].should == "2"
-        data["per_page"].should == "1"
-        data.keys.sort.should == ['page', 'per_page']
+        expect(data["page"]).to eq("2")
+        expect(data["per_page"]).to eq("1")
+        expect(data.keys.sort).to eq(['page', 'per_page'])
       end
     end
   end
@@ -887,8 +943,9 @@ describe Addressable::Template do
         Addressable::Template.new("http://example.com/{one}/{two}/")
       }
       it "builds a new pattern" do
-        subject.partial_expand(:one => "1").pattern.should ==
+        expect(subject.partial_expand(:one => "1").pattern).to eq(
           "http://example.com/1/{two}/"
+        )
       end
     end
     context "partial_expand query with missing param in middle" do
@@ -896,8 +953,9 @@ describe Addressable::Template do
         Addressable::Template.new("http://example.com/{?one,two,three}/")
       }
       it "builds a new pattern" do
-        subject.partial_expand(:one => "1", :three => "3").pattern.should ==
+        expect(subject.partial_expand(:one => "1", :three => "3").pattern).to eq(
           "http://example.com/?one=1{&two}&three=3/"
+        )
       end
     end
     context "partial_expand with query string" do
@@ -905,8 +963,9 @@ describe Addressable::Template do
         Addressable::Template.new("http://example.com/{?two,one}/")
       }
       it "builds a new pattern" do
-        subject.partial_expand(:one => "1").pattern.should ==
+        expect(subject.partial_expand(:one => "1").pattern).to eq(
           "http://example.com/{?two}&one=1/"
+        )
       end
     end
     context "partial_expand with path operator" do
@@ -914,8 +973,9 @@ describe Addressable::Template do
         Addressable::Template.new("http://example.com{/one,two}/")
       }
       it "builds a new pattern" do
-        subject.partial_expand(:one => "1").pattern.should ==
+        expect(subject.partial_expand(:one => "1").pattern).to eq(
           "http://example.com/1{/two}/"
+        )
       end
     end
   end
@@ -925,8 +985,9 @@ describe Addressable::Template do
         Addressable::Template.new("http://example.com/{one}/{two}/")
       }
       it "builds a new pattern" do
-        subject.partial_expand("one" => "1").pattern.should ==
+        expect(subject.partial_expand("one" => "1").pattern).to eq(
           "http://example.com/1/{two}/"
+        )
       end
     end
     context "partial_expand query with missing param in middle" do
@@ -934,8 +995,9 @@ describe Addressable::Template do
         Addressable::Template.new("http://example.com/{?one,two,three}/")
       }
       it "builds a new pattern" do
-        subject.partial_expand("one" => "1", "three" => "3").pattern.should ==
+        expect(subject.partial_expand("one" => "1", "three" => "3").pattern).to eq(
           "http://example.com/?one=1{&two}&three=3/"
+        )
       end
     end
     context "partial_expand with query string" do
@@ -943,8 +1005,9 @@ describe Addressable::Template do
         Addressable::Template.new("http://example.com/{?two,one}/")
       }
       it "builds a new pattern" do
-        subject.partial_expand("one" => "1").pattern.should ==
+        expect(subject.partial_expand("one" => "1").pattern).to eq(
           "http://example.com/{?two}&one=1/"
+        )
       end
     end
     context "partial_expand with path operator" do
@@ -952,8 +1015,9 @@ describe Addressable::Template do
         Addressable::Template.new("http://example.com{/one,two}/")
       }
       it "builds a new pattern" do
-        subject.partial_expand("one" => "1").pattern.should ==
+        expect(subject.partial_expand("one" => "1").pattern).to eq(
           "http://example.com/1{/two}/"
+        )
       end
     end
   end
@@ -963,15 +1027,16 @@ describe Addressable::Template do
         Addressable::Template.new("http://example.com/search/{query}/")
       }
       it "processes spaces" do
-        subject.expand({"query" => "an example search query"},
-                      ExampleTwoProcessor).to_str.should ==
+        expect(subject.expand({"query" => "an example search query"},
+                      ExampleTwoProcessor).to_str).to eq(
           "http://example.com/search/an+example+search+query/"
+        )
       end
       it "validates" do
-        lambda{
+        expect{
           subject.expand({"query" => "Bogus!"},
                       ExampleTwoProcessor).to_str
-        }.should raise_error(Addressable::Template::InvalidTemplateValueError)
+        }.to raise_error(Addressable::Template::InvalidTemplateValueError)
       end
     end
     context "partial_expand query with missing param in middle" do
@@ -979,8 +1044,9 @@ describe Addressable::Template do
         Addressable::Template.new("http://example.com/{?one,two,three}/")
       }
       it "builds a new pattern" do
-        subject.partial_expand("one" => "1", "three" => "3").pattern.should ==
+        expect(subject.partial_expand("one" => "1", "three" => "3").pattern).to eq(
           "http://example.com/?one=1{&two}&three=3/"
+        )
       end
     end
     context "partial_expand with query string" do
@@ -988,8 +1054,9 @@ describe Addressable::Template do
         Addressable::Template.new("http://example.com/{?two,one}/")
       }
       it "builds a new pattern" do
-        subject.partial_expand("one" => "1").pattern.should ==
+        expect(subject.partial_expand("one" => "1").pattern).to eq(
           "http://example.com/{?two}&one=1/"
+        )
       end
     end
     context "partial_expand with path operator" do
@@ -997,8 +1064,9 @@ describe Addressable::Template do
         Addressable::Template.new("http://example.com{/one,two}/")
       }
       it "builds a new pattern" do
-        subject.partial_expand("one" => "1").pattern.should ==
+        expect(subject.partial_expand("one" => "1").pattern).to eq(
           "http://example.com/1{/two}/"
+        )
       end
     end
   end
@@ -1007,20 +1075,20 @@ describe Addressable::Template do
       subject { Addressable::Template.new("foo{foo}/{bar}baz") }
       it "can match" do
         data = subject.match("foofoo/bananabaz")
-        data.mapping["foo"].should == "foo"
-        data.mapping["bar"].should == "banana"
+        expect(data.mapping["foo"]).to eq("foo")
+        expect(data.mapping["bar"]).to eq("banana")
       end
       it "can fail" do
-        subject.match("bar/foo").should be_nil
-        subject.match("foobaz").should be_nil
+        expect(subject.match("bar/foo")).to be_nil
+        expect(subject.match("foobaz")).to be_nil
       end
       it "can match empty" do
         data = subject.match("foo/baz")
-        data.mapping["foo"].should == nil
-        data.mapping["bar"].should == nil
+        expect(data.mapping["foo"]).to eq(nil)
+        expect(data.mapping["bar"]).to eq(nil)
       end
       it "lists vars" do
-        subject.variables.should == ["foo", "bar"]
+        expect(subject.variables).to eq(["foo", "bar"])
       end
     end
 
@@ -1028,27 +1096,27 @@ describe Addressable::Template do
       subject { Addressable::Template.new("foo{+foo}{#bar}baz") }
       it "can match" do
         data = subject.match("foo/test/banana#bazbaz")
-        data.mapping["foo"].should == "/test/banana"
-        data.mapping["bar"].should == "baz"
+        expect(data.mapping["foo"]).to eq("/test/banana")
+        expect(data.mapping["bar"]).to eq("baz")
       end
       it "can match empty level 2 #" do
         data = subject.match("foo/test/bananabaz")
-        data.mapping["foo"].should == "/test/banana"
-        data.mapping["bar"].should == nil
+        expect(data.mapping["foo"]).to eq("/test/banana")
+        expect(data.mapping["bar"]).to eq(nil)
         data = subject.match("foo/test/banana#baz")
-        data.mapping["foo"].should == "/test/banana"
-        data.mapping["bar"].should == ""
+        expect(data.mapping["foo"]).to eq("/test/banana")
+        expect(data.mapping["bar"]).to eq("")
       end
       it "can match empty level 2 +" do
         data = subject.match("foobaz")
-        data.mapping["foo"].should == nil
-        data.mapping["bar"].should == nil
+        expect(data.mapping["foo"]).to eq(nil)
+        expect(data.mapping["bar"]).to eq(nil)
         data = subject.match("foo#barbaz")
-        data.mapping["foo"].should == nil
-        data.mapping["bar"].should == "bar"
+        expect(data.mapping["foo"]).to eq(nil)
+        expect(data.mapping["bar"]).to eq("bar")
       end
       it "lists vars" do
-        subject.variables.should == ["foo", "bar"]
+        expect(subject.variables).to eq(["foo", "bar"])
       end
     end
 
@@ -1057,56 +1125,56 @@ describe Addressable::Template do
         subject { Addressable::Template.new("foo{foo,bar}baz") }
         it "can match" do
           data = subject.match("foofoo,barbaz")
-          data.mapping["foo"].should == "foo"
-          data.mapping["bar"].should == "bar"
+          expect(data.mapping["foo"]).to eq("foo")
+          expect(data.mapping["bar"]).to eq("bar")
         end
         it "lists vars" do
-          subject.variables.should == ["foo", "bar"]
+          expect(subject.variables).to eq(["foo", "bar"])
         end
       end
       context "+ operator" do
         subject { Addressable::Template.new("foo{+foo,bar}baz") }
         it "can match" do
           data = subject.match("foofoo/bar,barbaz")
-          data.mapping["bar"].should == "foo/bar,bar"
-          data.mapping["foo"].should == ""
+          expect(data.mapping["bar"]).to eq("foo/bar,bar")
+          expect(data.mapping["foo"]).to eq("")
         end
         it "lists vars" do
-          subject.variables.should == ["foo", "bar"]
+          expect(subject.variables).to eq(["foo", "bar"])
         end
       end
       context ". operator" do
         subject { Addressable::Template.new("foo{.foo,bar}baz") }
         it "can match" do
           data = subject.match("foo.foo.barbaz")
-          data.mapping["foo"].should == "foo"
-          data.mapping["bar"].should == "bar"
+          expect(data.mapping["foo"]).to eq("foo")
+          expect(data.mapping["bar"]).to eq("bar")
         end
         it "lists vars" do
-          subject.variables.should == ["foo", "bar"]
+          expect(subject.variables).to eq(["foo", "bar"])
         end
       end
       context "/ operator" do
         subject { Addressable::Template.new("foo{/foo,bar}baz") }
         it "can match" do
           data = subject.match("foo/foo/barbaz")
-          data.mapping["foo"].should == "foo"
-          data.mapping["bar"].should == "bar"
+          expect(data.mapping["foo"]).to eq("foo")
+          expect(data.mapping["bar"]).to eq("bar")
         end
         it "lists vars" do
-          subject.variables.should == ["foo", "bar"]
+          expect(subject.variables).to eq(["foo", "bar"])
         end
       end
       context "; operator" do
         subject { Addressable::Template.new("foo{;foo,bar,baz}baz") }
         it "can match" do
           data = subject.match("foo;foo=bar%20baz;bar=foo;bazbaz")
-          data.mapping["foo"].should == "bar baz"
-          data.mapping["bar"].should == "foo"
-          data.mapping["baz"].should == ""
+          expect(data.mapping["foo"]).to eq("bar baz")
+          expect(data.mapping["bar"]).to eq("foo")
+          expect(data.mapping["baz"]).to eq("")
         end
         it "lists vars" do
-          subject.variables.should == %w(foo bar baz)
+          expect(subject.variables).to eq(%w(foo bar baz))
         end
       end
       context "? operator" do
@@ -1114,11 +1182,11 @@ describe Addressable::Template do
           subject { Addressable::Template.new("foo{?foo,bar}baz") }
           it "can match" do
             data = subject.match("foo?foo=bar%20baz&bar=foobaz")
-            data.mapping["foo"].should == "bar baz"
-            data.mapping["bar"].should == "foo"
+            expect(data.mapping["foo"]).to eq("bar baz")
+            expect(data.mapping["bar"]).to eq("foo")
           end
           it "lists vars" do
-            subject.variables.should == %w(foo bar)
+            expect(subject.variables).to eq(%w(foo bar))
           end
         end
 
@@ -1127,30 +1195,30 @@ describe Addressable::Template do
 
           it "can match empty" do
             data = subject.match("/path")
-            data.mapping["page"].should == nil
-            data.mapping["per_page"].should == nil
-            data.mapping.keys.sort.should == ['page', 'per_page']
+            expect(data.mapping["page"]).to eq(nil)
+            expect(data.mapping["per_page"]).to eq(nil)
+            expect(data.mapping.keys.sort).to eq(['page', 'per_page'])
           end
 
           it "can match first var" do
             data = subject.match("/path?page=1")
-            data.mapping["page"].should == "1"
-            data.mapping["per_page"].should == nil
-            data.mapping.keys.sort.should == ['page', 'per_page']
+            expect(data.mapping["page"]).to eq("1")
+            expect(data.mapping["per_page"]).to eq(nil)
+            expect(data.mapping.keys.sort).to eq(['page', 'per_page'])
           end
 
           it "can match second var" do
             data = subject.match("/path?per_page=1")
-            data.mapping["page"].should == nil
-            data.mapping["per_page"].should == "1"
-            data.mapping.keys.sort.should == ['page', 'per_page']
+            expect(data.mapping["page"]).to eq(nil)
+            expect(data.mapping["per_page"]).to eq("1")
+            expect(data.mapping.keys.sort).to eq(['page', 'per_page'])
           end
 
           it "can match both vars" do
             data = subject.match("/path?page=2&per_page=1")
-            data.mapping["page"].should == "2"
-            data.mapping["per_page"].should == "1"
-            data.mapping.keys.sort.should == ['page', 'per_page']
+            expect(data.mapping["page"]).to eq("2")
+            expect(data.mapping["per_page"]).to eq("1")
+            expect(data.mapping.keys.sort).to eq(['page', 'per_page'])
           end
         end
 
@@ -1158,11 +1226,11 @@ describe Addressable::Template do
           subject { Addressable::Template.new("http://cyberscore.dev/api/users{?username}") }
           it "can match" do
             data = subject.match("http://cyberscore.dev/api/users?username=foobaz")
-            data.mapping["username"].should == "foobaz"
+            expect(data.mapping["username"]).to eq("foobaz")
           end
           it "lists vars" do
-            subject.variables.should == %w(username)
-            subject.keys.should == %w(username)
+            expect(subject.variables).to eq(%w(username))
+            expect(subject.keys).to eq(%w(username))
           end
         end
       end
@@ -1170,11 +1238,11 @@ describe Addressable::Template do
         subject { Addressable::Template.new("foo{&foo,bar}baz") }
         it "can match" do
           data = subject.match("foo&foo=bar%20baz&bar=foobaz")
-          data.mapping["foo"].should == "bar baz"
-          data.mapping["bar"].should == "foo"
+          expect(data.mapping["foo"]).to eq("bar baz")
+          expect(data.mapping["bar"]).to eq("foo")
         end
         it "lists vars" do
-          subject.variables.should == %w(foo bar)
+          expect(subject.variables).to eq(%w(foo bar))
         end
       end
     end
@@ -1184,70 +1252,70 @@ describe Addressable::Template do
     context "EXPRESSION" do
       subject { Addressable::Template::EXPRESSION }
       it "should be able to match an expression" do
-        subject.should match("{foo}")
-        subject.should match("{foo,9}")
-        subject.should match("{foo.bar,baz}")
-        subject.should match("{+foo.bar,baz}")
-        subject.should match("{foo,foo%20bar}")
-        subject.should match("{#foo:20,baz*}")
-        subject.should match("stuff{#foo:20,baz*}things")
+        expect(subject).to match("{foo}")
+        expect(subject).to match("{foo,9}")
+        expect(subject).to match("{foo.bar,baz}")
+        expect(subject).to match("{+foo.bar,baz}")
+        expect(subject).to match("{foo,foo%20bar}")
+        expect(subject).to match("{#foo:20,baz*}")
+        expect(subject).to match("stuff{#foo:20,baz*}things")
       end
       it "should fail on non vars" do
-        subject.should_not match("!{foo")
-        subject.should_not match("{foo.bar.}")
-        subject.should_not match("!{}")
+        expect(subject).not_to match("!{foo")
+        expect(subject).not_to match("{foo.bar.}")
+        expect(subject).not_to match("!{}")
       end
     end
     context "VARNAME" do
       subject { Addressable::Template::VARNAME }
       it "should be able to match a variable" do
-        subject.should match("foo")
-        subject.should match("9")
-        subject.should match("foo.bar")
-        subject.should match("foo_bar")
-        subject.should match("foo_bar.baz")
-        subject.should match("foo%20bar")
-        subject.should match("foo%20bar.baz")
+        expect(subject).to match("foo")
+        expect(subject).to match("9")
+        expect(subject).to match("foo.bar")
+        expect(subject).to match("foo_bar")
+        expect(subject).to match("foo_bar.baz")
+        expect(subject).to match("foo%20bar")
+        expect(subject).to match("foo%20bar.baz")
       end
       it "should fail on non vars" do
-        subject.should_not match("!foo")
-        subject.should_not match("foo.bar.")
-        subject.should_not match("foo%2%00bar")
-        subject.should_not match("foo_ba%r")
-        subject.should_not match("foo_bar*")
-        subject.should_not match("foo_bar:20")
+        expect(subject).not_to match("!foo")
+        expect(subject).not_to match("foo.bar.")
+        expect(subject).not_to match("foo%2%00bar")
+        expect(subject).not_to match("foo_ba%r")
+        expect(subject).not_to match("foo_bar*")
+        expect(subject).not_to match("foo_bar:20")
       end
     end
     context "VARIABLE_LIST" do
       subject { Addressable::Template::VARIABLE_LIST }
       it "should be able to match a variable list" do
-        subject.should match("foo,bar")
-        subject.should match("foo")
-        subject.should match("foo,bar*,baz")
-        subject.should match("foo.bar,bar_baz*,baz:12")
+        expect(subject).to match("foo,bar")
+        expect(subject).to match("foo")
+        expect(subject).to match("foo,bar*,baz")
+        expect(subject).to match("foo.bar,bar_baz*,baz:12")
       end
       it "should fail on non vars" do
-        subject.should_not match(",foo,bar*,baz")
-        subject.should_not match("foo,*bar,baz")
-        subject.should_not match("foo,,bar*,baz")
+        expect(subject).not_to match(",foo,bar*,baz")
+        expect(subject).not_to match("foo,*bar,baz")
+        expect(subject).not_to match("foo,,bar*,baz")
       end
     end
     context "VARSPEC" do
       subject { Addressable::Template::VARSPEC }
       it "should be able to match a variable with modifier" do
-        subject.should match("9:8")
-        subject.should match("foo.bar*")
-        subject.should match("foo_bar:12")
-        subject.should match("foo_bar.baz*")
-        subject.should match("foo%20bar:12")
-        subject.should match("foo%20bar.baz*")
+        expect(subject).to match("9:8")
+        expect(subject).to match("foo.bar*")
+        expect(subject).to match("foo_bar:12")
+        expect(subject).to match("foo_bar.baz*")
+        expect(subject).to match("foo%20bar:12")
+        expect(subject).to match("foo%20bar.baz*")
       end
       it "should fail on non vars" do
-        subject.should_not match("!foo")
-        subject.should_not match("*foo")
-        subject.should_not match("fo*o")
-        subject.should_not match("fo:o")
-        subject.should_not match("foo:")
+        expect(subject).not_to match("!foo")
+        expect(subject).not_to match("*foo")
+        expect(subject).not_to match("fo*o")
+        expect(subject).not_to match("fo:o")
+        expect(subject).not_to match("foo:")
       end
     end
   end
@@ -1256,61 +1324,113 @@ end
 describe Addressable::Template::MatchData do
   let(:template) { Addressable::Template.new('{foo}/{bar}') }
   subject(:its) { template.match('ab/cd') }
-  its(:uri) { should == Addressable::URI.parse('ab/cd') }
-  its(:template) { should == template }
-  its(:mapping) { should == { 'foo' => 'ab', 'bar' => 'cd' } }
-  its(:variables) { should == ['foo', 'bar'] }
-  its(:keys) { should == ['foo', 'bar'] }
-  its(:names) { should == ['foo', 'bar'] }
-  its(:values) { should == ['ab', 'cd'] }
-  its(:captures) { should == ['ab', 'cd'] }
-  its(:to_a) { should == ['ab/cd', 'ab', 'cd'] }
-  its(:to_s) { should == 'ab/cd' }
-  its(:string) { should == its.to_s }
-  its(:pre_match) { should == "" }
-  its(:post_match) { should == "" }
+
+  describe '#uri' do
+    subject { super().uri }
+    it { is_expected.to eq(Addressable::URI.parse('ab/cd')) }
+  end
+
+  describe '#template' do
+    subject { super().template }
+    it { is_expected.to eq(template) }
+  end
+
+  describe '#mapping' do
+    subject { super().mapping }
+    it { is_expected.to eq({ 'foo' => 'ab', 'bar' => 'cd' }) }
+  end
+
+  describe '#variables' do
+    subject { super().variables }
+    it { is_expected.to eq(['foo', 'bar']) }
+  end
+
+  describe '#keys' do
+    subject { super().keys }
+    it { is_expected.to eq(['foo', 'bar']) }
+  end
+
+  describe '#names' do
+    subject { super().names }
+    it { is_expected.to eq(['foo', 'bar']) }
+  end
+
+  describe '#values' do
+    subject { super().values }
+    it { is_expected.to eq(['ab', 'cd']) }
+  end
+
+  describe '#captures' do
+    subject { super().captures }
+    it { is_expected.to eq(['ab', 'cd']) }
+  end
+
+  describe '#to_a' do
+    subject { super().to_a }
+    it { is_expected.to eq(['ab/cd', 'ab', 'cd']) }
+  end
+
+  describe '#to_s' do
+    subject { super().to_s }
+    it { is_expected.to eq('ab/cd') }
+  end
+
+  describe '#string' do
+    subject { super().string }
+    it { is_expected.to eq(its.to_s) }
+  end
+
+  describe '#pre_match' do
+    subject { super().pre_match }
+    it { is_expected.to eq("") }
+  end
+
+  describe '#post_match' do
+    subject { super().post_match }
+    it { is_expected.to eq("") }
+  end
 
   describe 'values_at' do
     it 'returns an array with the values' do
-      its.values_at(0, 2).should == ['ab/cd', 'cd']
+      expect(its.values_at(0, 2)).to eq(['ab/cd', 'cd'])
     end
     it 'allows mixing integer an string keys' do
-      its.values_at('foo', 1).should == ['ab', 'ab']
+      expect(its.values_at('foo', 1)).to eq(['ab', 'ab'])
     end
     it 'accepts unknown keys' do
-      its.values_at('baz', 'foo').should == [nil, 'ab']
+      expect(its.values_at('baz', 'foo')).to eq([nil, 'ab'])
     end
   end
 
   describe '[]' do
     context 'string key' do
       it 'returns the corresponding capture' do
-        its['foo'].should == 'ab'
-        its['bar'].should == 'cd'
+        expect(its['foo']).to eq('ab')
+        expect(its['bar']).to eq('cd')
       end
       it 'returns nil for unknown keys' do
-        its['baz'].should be_nil
+        expect(its['baz']).to be_nil
       end
     end
     context 'symbol key' do
       it 'returns the corresponding capture' do
-        its[:foo].should == 'ab'
-        its[:bar].should == 'cd'
+        expect(its[:foo]).to eq('ab')
+        expect(its[:bar]).to eq('cd')
       end
       it 'returns nil for unknown keys' do
-        its[:baz].should be_nil
+        expect(its[:baz]).to be_nil
       end
     end
     context 'integer key' do
       it 'returns the full URI for index 0' do
-        its[0].should == 'ab/cd'
+        expect(its[0]).to eq('ab/cd')
       end
       it 'returns the corresponding capture' do
-        its[1].should == 'ab'
-        its[2].should == 'cd'
+        expect(its[1]).to eq('ab')
+        expect(its[2]).to eq('cd')
       end
       it 'returns nil for unknown keys' do
-        its[3].should be_nil
+        expect(its[3]).to be_nil
       end
     end
     context 'other key' do
@@ -1320,8 +1440,8 @@ describe Addressable::Template::MatchData do
     end
     context 'with length' do
       it 'returns an array starting at index with given length' do
-        its[0, 2].should == ['ab/cd', 'ab']
-        its[2, 1].should == ['cd']
+        expect(its[0, 2]).to eq(['ab/cd', 'ab'])
+        expect(its[2, 1]).to eq(['cd'])
       end
     end
   end

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -62,106 +62,106 @@ end
 
 describe Addressable::URI, "when created with a non-numeric port number" do
   it "should raise an error" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.new(:port => "bogus")
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 end
 
 describe Addressable::URI, "when created with a non-string scheme" do
   it "should raise an error" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.new(:scheme => :bogus)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 end
 
 describe Addressable::URI, "when created with a non-string user" do
   it "should raise an error" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.new(:user => :bogus)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 end
 
 describe Addressable::URI, "when created with a non-string password" do
   it "should raise an error" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.new(:password => :bogus)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 end
 
 describe Addressable::URI, "when created with a non-string userinfo" do
   it "should raise an error" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.new(:userinfo => :bogus)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 end
 
 describe Addressable::URI, "when created with a non-string host" do
   it "should raise an error" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.new(:host => :bogus)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 end
 
 describe Addressable::URI, "when created with a non-string authority" do
   it "should raise an error" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.new(:authority => :bogus)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 end
 
 describe Addressable::URI, "when created with a non-string authority" do
   it "should raise an error" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.new(:authority => :bogus)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 end
 
 describe Addressable::URI, "when created with a non-string path" do
   it "should raise an error" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.new(:path => :bogus)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 end
 
 describe Addressable::URI, "when created with a non-string query" do
   it "should raise an error" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.new(:query => :bogus)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 end
 
 describe Addressable::URI, "when created with a non-string fragment" do
   it "should raise an error" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.new(:fragment => :bogus)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 end
 
 describe Addressable::URI, "when created with a scheme but no hierarchical " +
     "segment" do
   it "should raise an error" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.parse("http:")
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 end
 
 describe Addressable::URI, "when created with an invalid host" do
   it "should raise an error" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.new(:host => "<invalid>")
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 end
 
@@ -171,61 +171,61 @@ describe Addressable::URI, "when created from nil components" do
   end
 
   it "should have a nil site value" do
-    @uri.site.should == nil
+    expect(@uri.site).to eq(nil)
   end
 
   it "should have an empty path" do
-    @uri.path.should == ""
+    expect(@uri.path).to eq("")
   end
 
   it "should be an empty uri" do
-    @uri.to_s.should == ""
+    expect(@uri.to_s).to eq("")
   end
 
   it "should have a nil default port" do
-    @uri.default_port.should == nil
+    expect(@uri.default_port).to eq(nil)
   end
 
   it "should be empty" do
-    @uri.should be_empty
+    expect(@uri).to be_empty
   end
 
   it "should raise an error if the scheme is set to whitespace" do
-    (lambda do
+    expect(lambda do
       @uri.scheme = "\t \n"
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 
   it "should raise an error if the scheme is set to all digits" do
-    (lambda do
+    expect(lambda do
       @uri.scheme = "123"
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 
   it "should raise an error if set into an invalid state" do
-    (lambda do
+    expect(lambda do
       @uri.user = "user"
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 
   it "should raise an error if set into an invalid state" do
-    (lambda do
+    expect(lambda do
       @uri.password = "pass"
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 
   it "should raise an error if set into an invalid state" do
-    (lambda do
+    expect(lambda do
       @uri.scheme = "http"
       @uri.fragment = "fragment"
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 
   it "should raise an error if set into an invalid state" do
-    (lambda do
+    expect(lambda do
       @uri.fragment = "fragment"
       @uri.scheme = "http"
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 end
 
@@ -244,112 +244,113 @@ describe Addressable::URI, "when initialized from individual components" do
   end
 
   it "returns 'http' for #scheme" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "returns 'http' for #normalized_scheme" do
-    @uri.normalized_scheme.should == "http"
+    expect(@uri.normalized_scheme).to eq("http")
   end
 
   it "returns 'user' for #user" do
-    @uri.user.should == "user"
+    expect(@uri.user).to eq("user")
   end
 
   it "returns 'user' for #normalized_user" do
-    @uri.normalized_user.should == "user"
+    expect(@uri.normalized_user).to eq("user")
   end
 
   it "returns 'password' for #password" do
-    @uri.password.should == "password"
+    expect(@uri.password).to eq("password")
   end
 
   it "returns 'password' for #normalized_password" do
-    @uri.normalized_password.should == "password"
+    expect(@uri.normalized_password).to eq("password")
   end
 
   it "returns 'user:password' for #userinfo" do
-    @uri.userinfo.should == "user:password"
+    expect(@uri.userinfo).to eq("user:password")
   end
 
   it "returns 'user:password' for #normalized_userinfo" do
-    @uri.normalized_userinfo.should == "user:password"
+    expect(@uri.normalized_userinfo).to eq("user:password")
   end
 
   it "returns 'example.com' for #host" do
-    @uri.host.should == "example.com"
+    expect(@uri.host).to eq("example.com")
   end
 
   it "returns 'example.com' for #normalized_host" do
-    @uri.normalized_host.should == "example.com"
+    expect(@uri.normalized_host).to eq("example.com")
   end
 
   it "returns 'user:password@example.com:8080' for #authority" do
-    @uri.authority.should == "user:password@example.com:8080"
+    expect(@uri.authority).to eq("user:password@example.com:8080")
   end
 
   it "returns 'user:password@example.com:8080' for #normalized_authority" do
-    @uri.normalized_authority.should == "user:password@example.com:8080"
+    expect(@uri.normalized_authority).to eq("user:password@example.com:8080")
   end
 
   it "returns 8080 for #port" do
-    @uri.port.should == 8080
+    expect(@uri.port).to eq(8080)
   end
 
   it "returns 8080 for #normalized_port" do
-    @uri.normalized_port.should == 8080
+    expect(@uri.normalized_port).to eq(8080)
   end
 
   it "returns 80 for #default_port" do
-    @uri.default_port.should == 80
+    expect(@uri.default_port).to eq(80)
   end
 
   it "returns 'http://user:password@example.com:8080' for #site" do
-    @uri.site.should == "http://user:password@example.com:8080"
+    expect(@uri.site).to eq("http://user:password@example.com:8080")
   end
 
   it "returns 'http://user:password@example.com:8080' for #normalized_site" do
-    @uri.normalized_site.should == "http://user:password@example.com:8080"
+    expect(@uri.normalized_site).to eq("http://user:password@example.com:8080")
   end
 
   it "returns '/path' for #path" do
-    @uri.path.should == "/path"
+    expect(@uri.path).to eq("/path")
   end
 
   it "returns '/path' for #normalized_path" do
-    @uri.normalized_path.should == "/path"
+    expect(@uri.normalized_path).to eq("/path")
   end
 
   it "returns 'query=value' for #query" do
-    @uri.query.should == "query=value"
+    expect(@uri.query).to eq("query=value")
   end
 
   it "returns 'query=value' for #normalized_query" do
-    @uri.normalized_query.should == "query=value"
+    expect(@uri.normalized_query).to eq("query=value")
   end
 
   it "returns 'fragment' for #fragment" do
-    @uri.fragment.should == "fragment"
+    expect(@uri.fragment).to eq("fragment")
   end
 
   it "returns 'fragment' for #normalized_fragment" do
-    @uri.normalized_fragment.should == "fragment"
+    expect(@uri.normalized_fragment).to eq("fragment")
   end
 
   it "returns #hash" do
-    @uri.hash.should_not be nil
+    expect(@uri.hash).not_to be nil
   end
 
   it "returns #to_s" do
-    @uri.to_s.should ==
+    expect(@uri.to_s).to eq(
       "http://user:password@example.com:8080/path?query=value#fragment"
+    )
   end
 
   it "should not be empty" do
-    @uri.should_not be_empty
+    expect(@uri).not_to be_empty
   end
 
   it "should not be frozen" do
-    @uri.should_not be_frozen
+    expect(@uri).not_to be_frozen
   end
 
   it "should allow destructive operations" do
@@ -373,112 +374,113 @@ describe Addressable::URI, "when initialized from " +
   end
 
   it "returns 'http' for #scheme" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "returns 'http' for #normalized_scheme" do
-    @uri.normalized_scheme.should == "http"
+    expect(@uri.normalized_scheme).to eq("http")
   end
 
   it "returns 'user' for #user" do
-    @uri.user.should == "user"
+    expect(@uri.user).to eq("user")
   end
 
   it "returns 'user' for #normalized_user" do
-    @uri.normalized_user.should == "user"
+    expect(@uri.normalized_user).to eq("user")
   end
 
   it "returns 'password' for #password" do
-    @uri.password.should == "password"
+    expect(@uri.password).to eq("password")
   end
 
   it "returns 'password' for #normalized_password" do
-    @uri.normalized_password.should == "password"
+    expect(@uri.normalized_password).to eq("password")
   end
 
   it "returns 'user:password' for #userinfo" do
-    @uri.userinfo.should == "user:password"
+    expect(@uri.userinfo).to eq("user:password")
   end
 
   it "returns 'user:password' for #normalized_userinfo" do
-    @uri.normalized_userinfo.should == "user:password"
+    expect(@uri.normalized_userinfo).to eq("user:password")
   end
 
   it "returns 'example.com' for #host" do
-    @uri.host.should == "example.com"
+    expect(@uri.host).to eq("example.com")
   end
 
   it "returns 'example.com' for #normalized_host" do
-    @uri.normalized_host.should == "example.com"
+    expect(@uri.normalized_host).to eq("example.com")
   end
 
   it "returns 'user:password@example.com:8080' for #authority" do
-    @uri.authority.should == "user:password@example.com:8080"
+    expect(@uri.authority).to eq("user:password@example.com:8080")
   end
 
   it "returns 'user:password@example.com:8080' for #normalized_authority" do
-    @uri.normalized_authority.should == "user:password@example.com:8080"
+    expect(@uri.normalized_authority).to eq("user:password@example.com:8080")
   end
 
   it "returns 8080 for #port" do
-    @uri.port.should == 8080
+    expect(@uri.port).to eq(8080)
   end
 
   it "returns 8080 for #normalized_port" do
-    @uri.normalized_port.should == 8080
+    expect(@uri.normalized_port).to eq(8080)
   end
 
   it "returns 80 for #default_port" do
-    @uri.default_port.should == 80
+    expect(@uri.default_port).to eq(80)
   end
 
   it "returns 'http://user:password@example.com:8080' for #site" do
-    @uri.site.should == "http://user:password@example.com:8080"
+    expect(@uri.site).to eq("http://user:password@example.com:8080")
   end
 
   it "returns 'http://user:password@example.com:8080' for #normalized_site" do
-    @uri.normalized_site.should == "http://user:password@example.com:8080"
+    expect(@uri.normalized_site).to eq("http://user:password@example.com:8080")
   end
 
   it "returns '/path' for #path" do
-    @uri.path.should == "/path"
+    expect(@uri.path).to eq("/path")
   end
 
   it "returns '/path' for #normalized_path" do
-    @uri.normalized_path.should == "/path"
+    expect(@uri.normalized_path).to eq("/path")
   end
 
   it "returns 'query=value' for #query" do
-    @uri.query.should == "query=value"
+    expect(@uri.query).to eq("query=value")
   end
 
   it "returns 'query=value' for #normalized_query" do
-    @uri.normalized_query.should == "query=value"
+    expect(@uri.normalized_query).to eq("query=value")
   end
 
   it "returns 'fragment' for #fragment" do
-    @uri.fragment.should == "fragment"
+    expect(@uri.fragment).to eq("fragment")
   end
 
   it "returns 'fragment' for #normalized_fragment" do
-    @uri.normalized_fragment.should == "fragment"
+    expect(@uri.normalized_fragment).to eq("fragment")
   end
 
   it "returns #hash" do
-    @uri.hash.should_not be nil
+    expect(@uri.hash).not_to be nil
   end
 
   it "returns #to_s" do
-    @uri.to_s.should ==
+    expect(@uri.to_s).to eq(
       "http://user:password@example.com:8080/path?query=value#fragment"
+    )
   end
 
   it "should not be empty" do
-    @uri.should_not be_empty
+    expect(@uri).not_to be_empty
   end
 
   it "should not be frozen" do
-    @uri.should_not be_frozen
+    expect(@uri).not_to be_frozen
   end
 
   it "should allow destructive operations" do
@@ -494,112 +496,113 @@ describe Addressable::URI, "when parsed from a frozen string" do
   end
 
   it "returns 'http' for #scheme" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "returns 'http' for #normalized_scheme" do
-    @uri.normalized_scheme.should == "http"
+    expect(@uri.normalized_scheme).to eq("http")
   end
 
   it "returns 'user' for #user" do
-    @uri.user.should == "user"
+    expect(@uri.user).to eq("user")
   end
 
   it "returns 'user' for #normalized_user" do
-    @uri.normalized_user.should == "user"
+    expect(@uri.normalized_user).to eq("user")
   end
 
   it "returns 'password' for #password" do
-    @uri.password.should == "password"
+    expect(@uri.password).to eq("password")
   end
 
   it "returns 'password' for #normalized_password" do
-    @uri.normalized_password.should == "password"
+    expect(@uri.normalized_password).to eq("password")
   end
 
   it "returns 'user:password' for #userinfo" do
-    @uri.userinfo.should == "user:password"
+    expect(@uri.userinfo).to eq("user:password")
   end
 
   it "returns 'user:password' for #normalized_userinfo" do
-    @uri.normalized_userinfo.should == "user:password"
+    expect(@uri.normalized_userinfo).to eq("user:password")
   end
 
   it "returns 'example.com' for #host" do
-    @uri.host.should == "example.com"
+    expect(@uri.host).to eq("example.com")
   end
 
   it "returns 'example.com' for #normalized_host" do
-    @uri.normalized_host.should == "example.com"
+    expect(@uri.normalized_host).to eq("example.com")
   end
 
   it "returns 'user:password@example.com:8080' for #authority" do
-    @uri.authority.should == "user:password@example.com:8080"
+    expect(@uri.authority).to eq("user:password@example.com:8080")
   end
 
   it "returns 'user:password@example.com:8080' for #normalized_authority" do
-    @uri.normalized_authority.should == "user:password@example.com:8080"
+    expect(@uri.normalized_authority).to eq("user:password@example.com:8080")
   end
 
   it "returns 8080 for #port" do
-    @uri.port.should == 8080
+    expect(@uri.port).to eq(8080)
   end
 
   it "returns 8080 for #normalized_port" do
-    @uri.normalized_port.should == 8080
+    expect(@uri.normalized_port).to eq(8080)
   end
 
   it "returns 80 for #default_port" do
-    @uri.default_port.should == 80
+    expect(@uri.default_port).to eq(80)
   end
 
   it "returns 'http://user:password@example.com:8080' for #site" do
-    @uri.site.should == "http://user:password@example.com:8080"
+    expect(@uri.site).to eq("http://user:password@example.com:8080")
   end
 
   it "returns 'http://user:password@example.com:8080' for #normalized_site" do
-    @uri.normalized_site.should == "http://user:password@example.com:8080"
+    expect(@uri.normalized_site).to eq("http://user:password@example.com:8080")
   end
 
   it "returns '/path' for #path" do
-    @uri.path.should == "/path"
+    expect(@uri.path).to eq("/path")
   end
 
   it "returns '/path' for #normalized_path" do
-    @uri.normalized_path.should == "/path"
+    expect(@uri.normalized_path).to eq("/path")
   end
 
   it "returns 'query=value' for #query" do
-    @uri.query.should == "query=value"
+    expect(@uri.query).to eq("query=value")
   end
 
   it "returns 'query=value' for #normalized_query" do
-    @uri.normalized_query.should == "query=value"
+    expect(@uri.normalized_query).to eq("query=value")
   end
 
   it "returns 'fragment' for #fragment" do
-    @uri.fragment.should == "fragment"
+    expect(@uri.fragment).to eq("fragment")
   end
 
   it "returns 'fragment' for #normalized_fragment" do
-    @uri.normalized_fragment.should == "fragment"
+    expect(@uri.normalized_fragment).to eq("fragment")
   end
 
   it "returns #hash" do
-    @uri.hash.should_not be nil
+    expect(@uri.hash).not_to be nil
   end
 
   it "returns #to_s" do
-    @uri.to_s.should ==
+    expect(@uri.to_s).to eq(
       "http://user:password@example.com:8080/path?query=value#fragment"
+    )
   end
 
   it "should not be empty" do
-    @uri.should_not be_empty
+    expect(@uri).not_to be_empty
   end
 
   it "should not be frozen" do
-    @uri.should_not be_frozen
+    expect(@uri).not_to be_frozen
   end
 
   it "should allow destructive operations" do
@@ -613,121 +616,121 @@ describe Addressable::URI, "when frozen" do
   end
 
   it "returns nil for #scheme" do
-    @uri.scheme.should == nil
+    expect(@uri.scheme).to eq(nil)
   end
 
   it "returns nil for #normalized_scheme" do
-    @uri.normalized_scheme.should == nil
+    expect(@uri.normalized_scheme).to eq(nil)
   end
 
   it "returns nil for #user" do
-    @uri.user.should == nil
+    expect(@uri.user).to eq(nil)
   end
 
   it "returns nil for #normalized_user" do
-    @uri.normalized_user.should == nil
+    expect(@uri.normalized_user).to eq(nil)
   end
 
   it "returns nil for #password" do
-    @uri.password.should == nil
+    expect(@uri.password).to eq(nil)
   end
 
   it "returns nil for #normalized_password" do
-    @uri.normalized_password.should == nil
+    expect(@uri.normalized_password).to eq(nil)
   end
 
   it "returns nil for #userinfo" do
-    @uri.userinfo.should == nil
+    expect(@uri.userinfo).to eq(nil)
   end
 
   it "returns nil for #normalized_userinfo" do
-    @uri.normalized_userinfo.should == nil
+    expect(@uri.normalized_userinfo).to eq(nil)
   end
 
   it "returns nil for #host" do
-    @uri.host.should == nil
+    expect(@uri.host).to eq(nil)
   end
 
   it "returns nil for #normalized_host" do
-    @uri.normalized_host.should == nil
+    expect(@uri.normalized_host).to eq(nil)
   end
 
   it "returns nil for #authority" do
-    @uri.authority.should == nil
+    expect(@uri.authority).to eq(nil)
   end
 
   it "returns nil for #normalized_authority" do
-    @uri.normalized_authority.should == nil
+    expect(@uri.normalized_authority).to eq(nil)
   end
 
   it "returns nil for #port" do
-    @uri.port.should == nil
+    expect(@uri.port).to eq(nil)
   end
 
   it "returns nil for #normalized_port" do
-    @uri.normalized_port.should == nil
+    expect(@uri.normalized_port).to eq(nil)
   end
 
   it "returns nil for #default_port" do
-    @uri.default_port.should == nil
+    expect(@uri.default_port).to eq(nil)
   end
 
   it "returns nil for #site" do
-    @uri.site.should == nil
+    expect(@uri.site).to eq(nil)
   end
 
   it "returns nil for #normalized_site" do
-    @uri.normalized_site.should == nil
+    expect(@uri.normalized_site).to eq(nil)
   end
 
   it "returns '' for #path" do
-    @uri.path.should == ''
+    expect(@uri.path).to eq('')
   end
 
   it "returns '' for #normalized_path" do
-    @uri.normalized_path.should == ''
+    expect(@uri.normalized_path).to eq('')
   end
 
   it "returns nil for #query" do
-    @uri.query.should == nil
+    expect(@uri.query).to eq(nil)
   end
 
   it "returns nil for #normalized_query" do
-    @uri.normalized_query.should == nil
+    expect(@uri.normalized_query).to eq(nil)
   end
 
   it "returns nil for #fragment" do
-    @uri.fragment.should == nil
+    expect(@uri.fragment).to eq(nil)
   end
 
   it "returns nil for #normalized_fragment" do
-    @uri.normalized_fragment.should == nil
+    expect(@uri.normalized_fragment).to eq(nil)
   end
 
   it "returns #hash" do
-    @uri.hash.should_not be nil
+    expect(@uri.hash).not_to be nil
   end
 
   it "returns #to_s" do
-    @uri.to_s.should == ''
+    expect(@uri.to_s).to eq('')
   end
 
   it "should be empty" do
-    @uri.should be_empty
+    expect(@uri).to be_empty
   end
 
   it "should be frozen" do
-    @uri.should be_frozen
+    expect(@uri).to be_frozen
   end
 
   it "should not be frozen after duping" do
-    @uri.dup.should_not be_frozen
+    expect(@uri.dup).not_to be_frozen
   end
 
   it "should not allow destructive operations" do
     expect { @uri.normalize! }.to raise_error { |error|
-      error.message.should match(/can't modify frozen/)
-      error.should satisfy { |e| RuntimeError === e || TypeError === e }
+      expect(error.message).to match(/can't modify frozen/)
+      expect(error).to satisfy { |e| RuntimeError === e || TypeError === e }
     }
   end
 end
@@ -740,130 +743,130 @@ describe Addressable::URI, "when frozen" do
   end
 
   it "returns 'HTTP' for #scheme" do
-    @uri.scheme.should == "HTTP"
+    expect(@uri.scheme).to eq("HTTP")
   end
 
   it "returns 'http' for #normalized_scheme" do
-    @uri.normalized_scheme.should == "http"
-    @uri.normalize.scheme.should == "http"
+    expect(@uri.normalized_scheme).to eq("http")
+    expect(@uri.normalize.scheme).to eq("http")
   end
 
   it "returns nil for #user" do
-    @uri.user.should == nil
+    expect(@uri.user).to eq(nil)
   end
 
   it "returns nil for #normalized_user" do
-    @uri.normalized_user.should == nil
+    expect(@uri.normalized_user).to eq(nil)
   end
 
   it "returns nil for #password" do
-    @uri.password.should == nil
+    expect(@uri.password).to eq(nil)
   end
 
   it "returns nil for #normalized_password" do
-    @uri.normalized_password.should == nil
+    expect(@uri.normalized_password).to eq(nil)
   end
 
   it "returns nil for #userinfo" do
-    @uri.userinfo.should == nil
+    expect(@uri.userinfo).to eq(nil)
   end
 
   it "returns nil for #normalized_userinfo" do
-    @uri.normalized_userinfo.should == nil
+    expect(@uri.normalized_userinfo).to eq(nil)
   end
 
   it "returns 'example.com.' for #host" do
-    @uri.host.should == "example.com."
+    expect(@uri.host).to eq("example.com.")
   end
 
   it "returns nil for #normalized_host" do
-    @uri.normalized_host.should == "example.com"
-    @uri.normalize.host.should == "example.com"
+    expect(@uri.normalized_host).to eq("example.com")
+    expect(@uri.normalize.host).to eq("example.com")
   end
 
   it "returns 'example.com.:80' for #authority" do
-    @uri.authority.should == "example.com.:80"
+    expect(@uri.authority).to eq("example.com.:80")
   end
 
   it "returns 'example.com:80' for #normalized_authority" do
-    @uri.normalized_authority.should == "example.com"
-    @uri.normalize.authority.should == "example.com"
+    expect(@uri.normalized_authority).to eq("example.com")
+    expect(@uri.normalize.authority).to eq("example.com")
   end
 
   it "returns 80 for #port" do
-    @uri.port.should == 80
+    expect(@uri.port).to eq(80)
   end
 
   it "returns nil for #normalized_port" do
-    @uri.normalized_port.should == nil
-    @uri.normalize.port.should == nil
+    expect(@uri.normalized_port).to eq(nil)
+    expect(@uri.normalize.port).to eq(nil)
   end
 
   it "returns 80 for #default_port" do
-    @uri.default_port.should == 80
+    expect(@uri.default_port).to eq(80)
   end
 
   it "returns 'HTTP://example.com.:80' for #site" do
-    @uri.site.should == "HTTP://example.com.:80"
+    expect(@uri.site).to eq("HTTP://example.com.:80")
   end
 
   it "returns 'http://example.com' for #normalized_site" do
-    @uri.normalized_site.should == "http://example.com"
-    @uri.normalize.site.should == "http://example.com"
+    expect(@uri.normalized_site).to eq("http://example.com")
+    expect(@uri.normalize.site).to eq("http://example.com")
   end
 
   it "returns '/%70a%74%68' for #path" do
-    @uri.path.should == "/%70a%74%68"
+    expect(@uri.path).to eq("/%70a%74%68")
   end
 
   it "returns '/path' for #normalized_path" do
-    @uri.normalized_path.should == "/path"
-    @uri.normalize.path.should == "/path"
+    expect(@uri.normalized_path).to eq("/path")
+    expect(@uri.normalize.path).to eq("/path")
   end
 
   it "returns 'a=%31' for #query" do
-    @uri.query.should == "a=%31"
+    expect(@uri.query).to eq("a=%31")
   end
 
   it "returns 'a=1' for #normalized_query" do
-    @uri.normalized_query.should == "a=1"
-    @uri.normalize.query.should == "a=1"
+    expect(@uri.normalized_query).to eq("a=1")
+    expect(@uri.normalize.query).to eq("a=1")
   end
 
   it "returns '1%323' for #fragment" do
-    @uri.fragment.should == "1%323"
+    expect(@uri.fragment).to eq("1%323")
   end
 
   it "returns '123' for #normalized_fragment" do
-    @uri.normalized_fragment.should == "123"
-    @uri.normalize.fragment.should == "123"
+    expect(@uri.normalized_fragment).to eq("123")
+    expect(@uri.normalize.fragment).to eq("123")
   end
 
   it "returns #hash" do
-    @uri.hash.should_not be nil
+    expect(@uri.hash).not_to be nil
   end
 
   it "returns #to_s" do
-    @uri.to_s.should == 'HTTP://example.com.:80/%70a%74%68?a=%31#1%323'
-    @uri.normalize.to_s.should == 'http://example.com/path?a=1#123'
+    expect(@uri.to_s).to eq('HTTP://example.com.:80/%70a%74%68?a=%31#1%323')
+    expect(@uri.normalize.to_s).to eq('http://example.com/path?a=1#123')
   end
 
   it "should not be empty" do
-    @uri.should_not be_empty
+    expect(@uri).not_to be_empty
   end
 
   it "should be frozen" do
-    @uri.should be_frozen
+    expect(@uri).to be_frozen
   end
 
   it "should not be frozen after duping" do
-    @uri.dup.should_not be_frozen
+    expect(@uri.dup).not_to be_frozen
   end
 
   it "should not allow destructive operations" do
     expect { @uri.normalize! }.to raise_error { |error|
-      error.message.should match(/can't modify frozen/)
-      error.should satisfy { |e| RuntimeError === e || TypeError === e }
+      expect(error.message).to match(/can't modify frozen/)
+      expect(error).to satisfy { |e| RuntimeError === e || TypeError === e }
     }
   end
 end
@@ -876,39 +879,39 @@ describe Addressable::URI, "when created from string components" do
   end
 
   it "should have a site value of 'http://example.com'" do
-    @uri.site.should == "http://example.com"
+    expect(@uri.site).to eq("http://example.com")
   end
 
   it "should be equal to the equivalent parsed URI" do
-    @uri.should == Addressable::URI.parse("http://example.com")
+    expect(@uri).to eq(Addressable::URI.parse("http://example.com"))
   end
 
   it "should raise an error if invalid components omitted" do
-    (lambda do
+    expect(lambda do
       @uri.omit(:bogus)
-    end).should raise_error(ArgumentError)
-    (lambda do
+    end).to raise_error(ArgumentError)
+    expect(lambda do
       @uri.omit(:scheme, :bogus, :path)
-    end).should raise_error(ArgumentError)
+    end).to raise_error(ArgumentError)
   end
 end
 
 describe Addressable::URI, "when created with a nil host but " +
     "non-nil authority components" do
   it "should raise an error" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.new(:user => "user", :password => "pass", :port => 80)
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 end
 
 describe Addressable::URI, "when created with both an authority and a user" do
   it "should raise an error" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.new(
         :user => "user", :authority => "user@example.com:80"
       )
-    end).should raise_error(ArgumentError)
+    end).to raise_error(ArgumentError)
   end
 end
 
@@ -918,17 +921,17 @@ describe Addressable::URI, "when created with an authority and no port" do
   end
 
   it "should not infer a port" do
-    @uri.port.should == nil
-    @uri.default_port.should == nil
-    @uri.inferred_port.should == nil
+    expect(@uri.port).to eq(nil)
+    expect(@uri.default_port).to eq(nil)
+    expect(@uri.inferred_port).to eq(nil)
   end
 
   it "should have a site value of '//user@example.com'" do
-    @uri.site.should == "//user@example.com"
+    expect(@uri.site).to eq("//user@example.com")
   end
 
   it "should have a 'null' origin" do
-    @uri.origin.should == 'null'
+    expect(@uri.origin).to eq('null')
   end
 end
 
@@ -938,16 +941,17 @@ describe Addressable::URI, "when created with a host with trailing dots" do
   end
 
   it "should have a stable normalized form" do
-    @uri.normalize.normalize.normalize.host.should ==
+    expect(@uri.normalize.normalize.normalize.host).to eq(
       @uri.normalize.host
+    )
   end
 end
 
 describe Addressable::URI, "when created with both a userinfo and a user" do
   it "should raise an error" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.new(:user => "user", :userinfo => "user:pass")
-    end).should raise_error(ArgumentError)
+    end).to raise_error(ArgumentError)
   end
 end
 
@@ -960,15 +964,15 @@ describe Addressable::URI, "when created with a path that hasn't been " +
   end
 
   it "should prefix a '/' to the path" do
-    @uri.should == Addressable::URI.parse("http://example.com/path")
+    expect(@uri).to eq(Addressable::URI.parse("http://example.com/path"))
   end
 
   it "should have a site value of 'http://example.com'" do
-    @uri.site.should == "http://example.com"
+    expect(@uri.site).to eq("http://example.com")
   end
 
   it "should have an origin of 'http://example.com" do
-    @uri.origin.should == 'http://example.com'
+    expect(@uri.origin).to eq('http://example.com')
   end
 end
 
@@ -981,15 +985,15 @@ describe Addressable::URI, "when created with a path that hasn't been " +
   end
 
   it "should not prefix a '/' to the path" do
-    @uri.should == Addressable::URI.parse("http:path")
+    expect(@uri).to eq(Addressable::URI.parse("http:path"))
   end
 
   it "should have a site value of 'http:'" do
-    @uri.site.should == "http:"
+    expect(@uri.site).to eq("http:")
   end
 
   it "should have a 'null' origin" do
-    @uri.origin.should == 'null'
+    expect(@uri.origin).to eq('null')
   end
 end
 
@@ -998,20 +1002,20 @@ describe Addressable::URI, "when parsed from an Addressable::URI object" do
     original_uri = Addressable::URI.parse("http://example.com/")
     new_uri = Addressable::URI.parse(original_uri)
     new_uri.host = 'www.example.com'
-    new_uri.host.should == 'www.example.com'
-    new_uri.to_s.should == 'http://www.example.com/'
-    original_uri.host.should == 'example.com'
-    original_uri.to_s.should == 'http://example.com/'
+    expect(new_uri.host).to eq('www.example.com')
+    expect(new_uri.to_s).to eq('http://www.example.com/')
+    expect(original_uri.host).to eq('example.com')
+    expect(original_uri.to_s).to eq('http://example.com/')
   end
 
   it "should not have unexpected side-effects" do
     original_uri = Addressable::URI.parse("http://example.com/")
     new_uri = Addressable::URI.heuristic_parse(original_uri)
     new_uri.host = 'www.example.com'
-    new_uri.host.should == 'www.example.com'
-    new_uri.to_s.should == 'http://www.example.com/'
-    original_uri.host.should == 'example.com'
-    original_uri.to_s.should == 'http://example.com/'
+    expect(new_uri.host).to eq('www.example.com')
+    expect(new_uri.to_s).to eq('http://www.example.com/')
+    expect(original_uri.host).to eq('example.com')
+    expect(original_uri.to_s).to eq('http://example.com/')
   end
 end
 
@@ -1019,9 +1023,9 @@ describe Addressable::URI, "when parsed from something that looks " +
     "like a URI object" do
   it "should parse without error" do
     uri = Addressable::URI.parse(Fake::URI::HTTP.new("http://example.com/"))
-    (lambda do
+    expect(lambda do
       Addressable::URI.parse(uri)
-    end).should_not raise_error
+    end).not_to raise_error
   end
 end
 
@@ -1031,31 +1035,31 @@ describe Addressable::URI, "when parsed from ''" do
   end
 
   it "should have no scheme" do
-    @uri.scheme.should == nil
+    expect(@uri.scheme).to eq(nil)
   end
 
   it "should not be considered to be ip-based" do
-    @uri.should_not be_ip_based
+    expect(@uri).not_to be_ip_based
   end
 
   it "should have a path of ''" do
-    @uri.path.should == ""
+    expect(@uri.path).to eq("")
   end
 
   it "should have a request URI of '/'" do
-    @uri.request_uri.should == "/"
+    expect(@uri.request_uri).to eq("/")
   end
 
   it "should be considered relative" do
-    @uri.should be_relative
+    expect(@uri).to be_relative
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should have a 'null' origin" do
-    @uri.origin.should == 'null'
+    expect(@uri.origin).to eq('null')
   end
 end
 
@@ -1067,35 +1071,35 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'ftp' scheme" do
-    @uri.scheme.should == "ftp"
+    expect(@uri.scheme).to eq("ftp")
   end
 
   it "should be considered to be ip-based" do
-    @uri.should be_ip_based
+    expect(@uri).to be_ip_based
   end
 
   it "should have a host of 'ftp.is.co.za'" do
-    @uri.host.should == "ftp.is.co.za"
+    expect(@uri.host).to eq("ftp.is.co.za")
   end
 
   it "should have inferred_port of 21" do
-    @uri.inferred_port.should == 21
+    expect(@uri.inferred_port).to eq(21)
   end
 
   it "should have a path of '/rfc/rfc1808.txt'" do
-    @uri.path.should == "/rfc/rfc1808.txt"
+    expect(@uri.path).to eq("/rfc/rfc1808.txt")
   end
 
   it "should not have a request URI" do
-    @uri.request_uri.should == nil
+    expect(@uri.request_uri).to eq(nil)
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should have an origin of 'ftp://ftp.is.co.za'" do
-    @uri.origin.should == 'ftp://ftp.is.co.za'
+    expect(@uri.origin).to eq('ftp://ftp.is.co.za')
   end
 end
 
@@ -1107,45 +1111,45 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'http' scheme" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "should be considered to be ip-based" do
-    @uri.should be_ip_based
+    expect(@uri).to be_ip_based
   end
 
   it "should have a host of 'www.ietf.org'" do
-    @uri.host.should == "www.ietf.org"
+    expect(@uri.host).to eq("www.ietf.org")
   end
 
   it "should have inferred_port of 80" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should have a path of '/rfc/rfc2396.txt'" do
-    @uri.path.should == "/rfc/rfc2396.txt"
+    expect(@uri.path).to eq("/rfc/rfc2396.txt")
   end
 
   it "should have a request URI of '/rfc/rfc2396.txt'" do
-    @uri.request_uri.should == "/rfc/rfc2396.txt"
+    expect(@uri.request_uri).to eq("/rfc/rfc2396.txt")
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should correctly omit components" do
-    @uri.omit(:scheme).to_s.should == "//www.ietf.org/rfc/rfc2396.txt"
-    @uri.omit(:path).to_s.should == "http://www.ietf.org"
+    expect(@uri.omit(:scheme).to_s).to eq("//www.ietf.org/rfc/rfc2396.txt")
+    expect(@uri.omit(:path).to_s).to eq("http://www.ietf.org")
   end
 
   it "should correctly omit components destructively" do
     @uri.omit!(:scheme)
-    @uri.to_s.should == "//www.ietf.org/rfc/rfc2396.txt"
+    expect(@uri.to_s).to eq("//www.ietf.org/rfc/rfc2396.txt")
   end
 
   it "should have an origin of 'http://www.ietf.org'" do
-    @uri.origin.should == 'http://www.ietf.org'
+    expect(@uri.origin).to eq('http://www.ietf.org')
   end
 end
 
@@ -1157,61 +1161,61 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'ldap' scheme" do
-    @uri.scheme.should == "ldap"
+    expect(@uri.scheme).to eq("ldap")
   end
 
   it "should be considered to be ip-based" do
-    @uri.should be_ip_based
+    expect(@uri).to be_ip_based
   end
 
   it "should have a host of '[2001:db8::7]'" do
-    @uri.host.should == "[2001:db8::7]"
+    expect(@uri.host).to eq("[2001:db8::7]")
   end
 
   it "should have inferred_port of 389" do
-    @uri.inferred_port.should == 389
+    expect(@uri.inferred_port).to eq(389)
   end
 
   it "should have a path of '/c=GB'" do
-    @uri.path.should == "/c=GB"
+    expect(@uri.path).to eq("/c=GB")
   end
 
   it "should not have a request URI" do
-    @uri.request_uri.should == nil
+    expect(@uri.request_uri).to eq(nil)
   end
 
   it "should not allow request URI assignment" do
-    (lambda do
+    expect(lambda do
       @uri.request_uri = "/"
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 
   it "should have a query of 'objectClass?one'" do
-    @uri.query.should == "objectClass?one"
+    expect(@uri.query).to eq("objectClass?one")
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should correctly omit components" do
-    @uri.omit(:scheme, :authority).to_s.should == "/c=GB?objectClass?one"
-    @uri.omit(:path).to_s.should == "ldap://[2001:db8::7]?objectClass?one"
+    expect(@uri.omit(:scheme, :authority).to_s).to eq("/c=GB?objectClass?one")
+    expect(@uri.omit(:path).to_s).to eq("ldap://[2001:db8::7]?objectClass?one")
   end
 
   it "should correctly omit components destructively" do
     @uri.omit!(:scheme, :authority)
-    @uri.to_s.should == "/c=GB?objectClass?one"
+    expect(@uri.to_s).to eq("/c=GB?objectClass?one")
   end
 
   it "should raise an error if omission would create an invalid URI" do
-    (lambda do
+    expect(lambda do
       @uri.omit(:authority, :path)
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 
   it "should have an origin of 'ldap://[2001:db8::7]'" do
-    @uri.origin.should == 'ldap://[2001:db8::7]'
+    expect(@uri.origin).to eq('ldap://[2001:db8::7]')
   end
 end
 
@@ -1223,31 +1227,31 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'mailto' scheme" do
-    @uri.scheme.should == "mailto"
+    expect(@uri.scheme).to eq("mailto")
   end
 
   it "should not be considered to be ip-based" do
-    @uri.should_not be_ip_based
+    expect(@uri).not_to be_ip_based
   end
 
   it "should not have an inferred_port" do
-    @uri.inferred_port.should == nil
+    expect(@uri.inferred_port).to eq(nil)
   end
 
   it "should have a path of 'John.Doe@example.com'" do
-    @uri.path.should == "John.Doe@example.com"
+    expect(@uri.path).to eq("John.Doe@example.com")
   end
 
   it "should not have a request URI" do
-    @uri.request_uri.should == nil
+    expect(@uri.request_uri).to eq(nil)
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should have a 'null' origin" do
-    @uri.origin.should == 'null'
+    expect(@uri.origin).to eq('null')
   end
 end
 
@@ -1261,37 +1265,37 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'mailto' scheme" do
-    @uri.scheme.should == "mailto"
+    expect(@uri.scheme).to eq("mailto")
   end
 
   it "should not be considered to be ip-based" do
-    @uri.should_not be_ip_based
+    expect(@uri).not_to be_ip_based
   end
 
   it "should not have an inferred_port" do
-    @uri.inferred_port.should == nil
+    expect(@uri.inferred_port).to eq(nil)
   end
 
   it "should have a path of ''" do
-    @uri.path.should == ""
+    expect(@uri.path).to eq("")
   end
 
   it "should not have a request URI" do
-    @uri.request_uri.should == nil
+    expect(@uri.request_uri).to eq(nil)
   end
 
   it "should have the To: field value parameterized" do
-    @uri.query_values(Hash)["to"].should == (
+    expect(@uri.query_values(Hash)["to"]).to eq(
       "addr1@an.example,addr2@an.example"
     )
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should have a 'null' origin" do
-    @uri.origin.should == 'null'
+    expect(@uri.origin).to eq('null')
   end
 end
 
@@ -1303,31 +1307,31 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'news' scheme" do
-    @uri.scheme.should == "news"
+    expect(@uri.scheme).to eq("news")
   end
 
   it "should not have an inferred_port" do
-    @uri.inferred_port.should == nil
+    expect(@uri.inferred_port).to eq(nil)
   end
 
   it "should not be considered to be ip-based" do
-    @uri.should_not be_ip_based
+    expect(@uri).not_to be_ip_based
   end
 
   it "should have a path of 'comp.infosystems.www.servers.unix'" do
-    @uri.path.should == "comp.infosystems.www.servers.unix"
+    expect(@uri.path).to eq("comp.infosystems.www.servers.unix")
   end
 
   it "should not have a request URI" do
-    @uri.request_uri.should == nil
+    expect(@uri.request_uri).to eq(nil)
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should have a 'null' origin" do
-    @uri.origin.should == 'null'
+    expect(@uri.origin).to eq('null')
   end
 end
 
@@ -1339,31 +1343,31 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'tel' scheme" do
-    @uri.scheme.should == "tel"
+    expect(@uri.scheme).to eq("tel")
   end
 
   it "should not be considered to be ip-based" do
-    @uri.should_not be_ip_based
+    expect(@uri).not_to be_ip_based
   end
 
   it "should not have an inferred_port" do
-    @uri.inferred_port.should == nil
+    expect(@uri.inferred_port).to eq(nil)
   end
 
   it "should have a path of '+1-816-555-1212'" do
-    @uri.path.should == "+1-816-555-1212"
+    expect(@uri.path).to eq("+1-816-555-1212")
   end
 
   it "should not have a request URI" do
-    @uri.request_uri.should == nil
+    expect(@uri.request_uri).to eq(nil)
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should have a 'null' origin" do
-    @uri.origin.should == 'null'
+    expect(@uri.origin).to eq('null')
   end
 end
 
@@ -1375,43 +1379,43 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'telnet' scheme" do
-    @uri.scheme.should == "telnet"
+    expect(@uri.scheme).to eq("telnet")
   end
 
   it "should have a host of '192.0.2.16'" do
-    @uri.host.should == "192.0.2.16"
+    expect(@uri.host).to eq("192.0.2.16")
   end
 
   it "should have a port of 80" do
-    @uri.port.should == 80
+    expect(@uri.port).to eq(80)
   end
 
   it "should have a inferred_port of 80" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should have a default_port of 23" do
-    @uri.default_port.should == 23
+    expect(@uri.default_port).to eq(23)
   end
 
   it "should be considered to be ip-based" do
-    @uri.should be_ip_based
+    expect(@uri).to be_ip_based
   end
 
   it "should have a path of '/'" do
-    @uri.path.should == "/"
+    expect(@uri.path).to eq("/")
   end
 
   it "should not have a request URI" do
-    @uri.request_uri.should == nil
+    expect(@uri.request_uri).to eq(nil)
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should have an origin of 'telnet://192.0.2.16:80'" do
-    @uri.origin.should == 'telnet://192.0.2.16:80'
+    expect(@uri.origin).to eq('telnet://192.0.2.16:80')
   end
 end
 
@@ -1424,32 +1428,32 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'urn' scheme" do
-    @uri.scheme.should == "urn"
+    expect(@uri.scheme).to eq("urn")
   end
 
   it "should not have an inferred_port" do
-    @uri.inferred_port.should == nil
+    expect(@uri.inferred_port).to eq(nil)
   end
 
   it "should not be considered to be ip-based" do
-    @uri.should_not be_ip_based
+    expect(@uri).not_to be_ip_based
   end
 
   it "should have a path of " +
       "'oasis:names:specification:docbook:dtd:xml:4.1.2'" do
-    @uri.path.should == "oasis:names:specification:docbook:dtd:xml:4.1.2"
+    expect(@uri.path).to eq("oasis:names:specification:docbook:dtd:xml:4.1.2")
   end
 
   it "should not have a request URI" do
-    @uri.request_uri.should == nil
+    expect(@uri.request_uri).to eq(nil)
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should have a 'null' origin" do
-    @uri.origin.should == 'null'
+    expect(@uri.origin).to eq('null')
   end
 end
 
@@ -1460,31 +1464,31 @@ describe Addressable::URI, "when heuristically parsed from " +
   end
 
   it "should use the 'http' scheme" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "should have a host of '192.0.2.16'" do
-    @uri.host.should == "192.0.2.16"
+    expect(@uri.host).to eq("192.0.2.16")
   end
 
   it "should have a port of '8000'" do
-    @uri.port.should == 8000
+    expect(@uri.port).to eq(8000)
   end
 
   it "should be considered to be ip-based" do
-    @uri.should be_ip_based
+    expect(@uri).to be_ip_based
   end
 
   it "should have a path of '/path'" do
-    @uri.path.should == "/path"
+    expect(@uri.path).to eq("/path")
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should have an origin of 'http://192.0.2.16:8000'" do
-    @uri.origin.should == 'http://192.0.2.16:8000'
+    expect(@uri.origin).to eq('http://192.0.2.16:8000')
   end
 end
 
@@ -1495,258 +1499,263 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "when inspected, should have the correct URI" do
-    @uri.inspect.should include("http://example.com")
+    expect(@uri.inspect).to include("http://example.com")
   end
 
   it "when inspected, should have the correct class name" do
-    @uri.inspect.should include("Addressable::URI")
+    expect(@uri.inspect).to include("Addressable::URI")
   end
 
   it "when inspected, should have the correct object id" do
-    @uri.inspect.should include("%#0x" % @uri.object_id)
+    expect(@uri.inspect).to include("%#0x" % @uri.object_id)
   end
 
   it "should use the 'http' scheme" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "should be considered to be ip-based" do
-    @uri.should be_ip_based
+    expect(@uri).to be_ip_based
   end
 
   it "should have an authority segment of 'example.com'" do
-    @uri.authority.should == "example.com"
+    expect(@uri.authority).to eq("example.com")
   end
 
   it "should have a host of 'example.com'" do
-    @uri.host.should == "example.com"
+    expect(@uri.host).to eq("example.com")
   end
 
   it "should be considered ip-based" do
-    @uri.should be_ip_based
+    expect(@uri).to be_ip_based
   end
 
   it "should have no username" do
-    @uri.user.should == nil
+    expect(@uri.user).to eq(nil)
   end
 
   it "should have no password" do
-    @uri.password.should == nil
+    expect(@uri.password).to eq(nil)
   end
 
   it "should use port 80" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should not have a specified port" do
-    @uri.port.should == nil
+    expect(@uri.port).to eq(nil)
   end
 
   it "should have an empty path" do
-    @uri.path.should == ""
+    expect(@uri.path).to eq("")
   end
 
   it "should have no query string" do
-    @uri.query.should == nil
-    @uri.query_values.should == nil
+    expect(@uri.query).to eq(nil)
+    expect(@uri.query_values).to eq(nil)
   end
 
   it "should have a request URI of '/'" do
-    @uri.request_uri.should == "/"
+    expect(@uri.request_uri).to eq("/")
   end
 
   it "should have no fragment" do
-    @uri.fragment.should == nil
+    expect(@uri.fragment).to eq(nil)
   end
 
   it "should be considered absolute" do
-    @uri.should be_absolute
+    expect(@uri).to be_absolute
   end
 
   it "should not be considered relative" do
-    @uri.should_not be_relative
+    expect(@uri).not_to be_relative
   end
 
   it "should not be exactly equal to 42" do
-    @uri.eql?(42).should == false
+    expect(@uri.eql?(42)).to eq(false)
   end
 
   it "should not be equal to 42" do
-    (@uri == 42).should == false
+    expect(@uri == 42).to eq(false)
   end
 
   it "should not be roughly equal to 42" do
-    (@uri === 42).should == false
+    expect(@uri === 42).to eq(false)
   end
 
   it "should be exactly equal to http://example.com" do
-    @uri.eql?(Addressable::URI.parse("http://example.com")).should == true
+    expect(@uri.eql?(Addressable::URI.parse("http://example.com"))).to eq(true)
   end
 
   it "should be roughly equal to http://example.com/" do
-    (@uri === Addressable::URI.parse("http://example.com/")).should == true
+    expect(@uri === Addressable::URI.parse("http://example.com/")).to eq(true)
   end
 
   it "should be roughly equal to the string 'http://example.com/'" do
-    (@uri === "http://example.com/").should == true
+    expect(@uri === "http://example.com/").to eq(true)
   end
 
   it "should not be roughly equal to the string " +
       "'http://example.com:bogus/'" do
-    (lambda do
-      (@uri === "http://example.com:bogus/").should == false
-    end).should_not raise_error
+    expect(lambda do
+      expect(@uri === "http://example.com:bogus/").to eq(false)
+    end).not_to raise_error
   end
 
   it "should result in itself when joined with itself" do
-    @uri.join(@uri).to_s.should == "http://example.com"
-    @uri.join!(@uri).to_s.should == "http://example.com"
+    expect(@uri.join(@uri).to_s).to eq("http://example.com")
+    expect(@uri.join!(@uri).to_s).to eq("http://example.com")
   end
 
   it "should be equivalent to http://EXAMPLE.com" do
-    @uri.should == Addressable::URI.parse("http://EXAMPLE.com")
+    expect(@uri).to eq(Addressable::URI.parse("http://EXAMPLE.com"))
   end
 
   it "should be equivalent to http://EXAMPLE.com:80/" do
-    @uri.should == Addressable::URI.parse("http://EXAMPLE.com:80/")
+    expect(@uri).to eq(Addressable::URI.parse("http://EXAMPLE.com:80/"))
   end
 
   it "should have the same hash as http://example.com" do
-    @uri.hash.should == Addressable::URI.parse("http://example.com").hash
+    expect(@uri.hash).to eq(Addressable::URI.parse("http://example.com").hash)
   end
 
   it "should have the same hash as http://EXAMPLE.com after assignment" do
     @uri.host = "EXAMPLE.com"
-    @uri.hash.should == Addressable::URI.parse("http://EXAMPLE.com").hash
+    expect(@uri.hash).to eq(Addressable::URI.parse("http://EXAMPLE.com").hash)
   end
 
   it "should have a different hash from http://EXAMPLE.com" do
-    @uri.hash.should_not == Addressable::URI.parse("http://EXAMPLE.com").hash
+    expect(@uri.hash).not_to eq(Addressable::URI.parse("http://EXAMPLE.com").hash)
   end
 
   # Section 6.2.3 of RFC 3986
   it "should be equivalent to http://example.com/" do
-    @uri.should == Addressable::URI.parse("http://example.com/")
+    expect(@uri).to eq(Addressable::URI.parse("http://example.com/"))
   end
 
   # Section 6.2.3 of RFC 3986
   it "should be equivalent to http://example.com:/" do
-    @uri.should == Addressable::URI.parse("http://example.com:/")
+    expect(@uri).to eq(Addressable::URI.parse("http://example.com:/"))
   end
 
   # Section 6.2.3 of RFC 3986
   it "should be equivalent to http://example.com:80/" do
-    @uri.should == Addressable::URI.parse("http://example.com:80/")
+    expect(@uri).to eq(Addressable::URI.parse("http://example.com:80/"))
   end
 
   # Section 6.2.2.1 of RFC 3986
   it "should be equivalent to http://EXAMPLE.COM/" do
-    @uri.should == Addressable::URI.parse("http://EXAMPLE.COM/")
+    expect(@uri).to eq(Addressable::URI.parse("http://EXAMPLE.COM/"))
   end
 
   it "should have a route of '/path/' to 'http://example.com/path/'" do
-    @uri.route_to("http://example.com/path/").should ==
+    expect(@uri.route_to("http://example.com/path/")).to eq(
       Addressable::URI.parse("/path/")
+    )
   end
 
   it "should have a route of '..' from 'http://example.com/path/'" do
-    @uri.route_from("http://example.com/path/").should ==
+    expect(@uri.route_from("http://example.com/path/")).to eq(
       Addressable::URI.parse("..")
+    )
   end
 
   it "should have a route of '#' to 'http://example.com/'" do
-    @uri.route_to("http://example.com/").should ==
+    expect(@uri.route_to("http://example.com/")).to eq(
       Addressable::URI.parse("#")
+    )
   end
 
   it "should have a route of 'http://elsewhere.com/' to " +
       "'http://elsewhere.com/'" do
-    @uri.route_to("http://elsewhere.com/").should ==
+    expect(@uri.route_to("http://elsewhere.com/")).to eq(
       Addressable::URI.parse("http://elsewhere.com/")
+    )
   end
 
   it "when joined with 'relative/path' should be " +
       "'http://example.com/relative/path'" do
-    @uri.join('relative/path').should ==
+    expect(@uri.join('relative/path')).to eq(
       Addressable::URI.parse("http://example.com/relative/path")
+    )
   end
 
   it "when joined with a bogus object a TypeError should be raised" do
-    (lambda do
+    expect(lambda do
       @uri.join(42)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "should have the correct username after assignment" do
     @uri.user = "newuser"
-    @uri.user.should == "newuser"
-    @uri.password.should == nil
-    @uri.to_s.should == "http://newuser@example.com"
+    expect(@uri.user).to eq("newuser")
+    expect(@uri.password).to eq(nil)
+    expect(@uri.to_s).to eq("http://newuser@example.com")
   end
 
   it "should have the correct username after assignment" do
     @uri.user = "user@123!"
-    @uri.user.should == "user@123!"
-    @uri.normalized_user.should == "user%40123%21"
-    @uri.password.should == nil
-    @uri.normalize.to_s.should == "http://user%40123%21@example.com/"
+    expect(@uri.user).to eq("user@123!")
+    expect(@uri.normalized_user).to eq("user%40123%21")
+    expect(@uri.password).to eq(nil)
+    expect(@uri.normalize.to_s).to eq("http://user%40123%21@example.com/")
   end
 
   it "should have the correct password after assignment" do
     @uri.password = "newpass"
-    @uri.password.should == "newpass"
-    @uri.user.should == ""
-    @uri.to_s.should == "http://:newpass@example.com"
+    expect(@uri.password).to eq("newpass")
+    expect(@uri.user).to eq("")
+    expect(@uri.to_s).to eq("http://:newpass@example.com")
   end
 
   it "should have the correct password after assignment" do
     @uri.password = "#secret@123!"
-    @uri.password.should == "#secret@123!"
-    @uri.normalized_password.should == "%23secret%40123%21"
-    @uri.user.should == ""
-    @uri.normalize.to_s.should == "http://:%23secret%40123%21@example.com/"
-    @uri.omit(:password).to_s.should == "http://example.com"
+    expect(@uri.password).to eq("#secret@123!")
+    expect(@uri.normalized_password).to eq("%23secret%40123%21")
+    expect(@uri.user).to eq("")
+    expect(@uri.normalize.to_s).to eq("http://:%23secret%40123%21@example.com/")
+    expect(@uri.omit(:password).to_s).to eq("http://example.com")
   end
 
   it "should have the correct user/pass after repeated assignment" do
     @uri.user = nil
-    @uri.user.should == nil
+    expect(@uri.user).to eq(nil)
     @uri.password = "newpass"
-    @uri.password.should == "newpass"
+    expect(@uri.password).to eq("newpass")
     # Username cannot be nil if the password is set
-    @uri.user.should == ""
-    @uri.to_s.should == "http://:newpass@example.com"
+    expect(@uri.user).to eq("")
+    expect(@uri.to_s).to eq("http://:newpass@example.com")
     @uri.user = "newuser"
-    @uri.user.should == "newuser"
+    expect(@uri.user).to eq("newuser")
     @uri.password = nil
-    @uri.password.should == nil
-    @uri.to_s.should == "http://newuser@example.com"
+    expect(@uri.password).to eq(nil)
+    expect(@uri.to_s).to eq("http://newuser@example.com")
     @uri.user = "newuser"
-    @uri.user.should == "newuser"
+    expect(@uri.user).to eq("newuser")
     @uri.password = ""
-    @uri.password.should == ""
-    @uri.to_s.should == "http://newuser:@example.com"
+    expect(@uri.password).to eq("")
+    expect(@uri.to_s).to eq("http://newuser:@example.com")
     @uri.password = "newpass"
-    @uri.password.should == "newpass"
+    expect(@uri.password).to eq("newpass")
     @uri.user = nil
     # Username cannot be nil if the password is set
-    @uri.user.should == ""
-    @uri.to_s.should == "http://:newpass@example.com"
+    expect(@uri.user).to eq("")
+    expect(@uri.to_s).to eq("http://:newpass@example.com")
   end
 
   it "should have the correct user/pass after userinfo assignment" do
     @uri.user = "newuser"
-    @uri.user.should == "newuser"
+    expect(@uri.user).to eq("newuser")
     @uri.password = "newpass"
-    @uri.password.should == "newpass"
+    expect(@uri.password).to eq("newpass")
     @uri.userinfo = nil
-    @uri.userinfo.should == nil
-    @uri.user.should == nil
-    @uri.password.should == nil
+    expect(@uri.userinfo).to eq(nil)
+    expect(@uri.user).to eq(nil)
+    expect(@uri.password).to eq(nil)
   end
 
   it "should correctly convert to a hash" do
-    @uri.to_hash.should == {
+    expect(@uri.to_hash).to eq({
       :scheme => "http",
       :user => nil,
       :password => nil,
@@ -1755,15 +1764,15 @@ describe Addressable::URI, "when parsed from " +
       :path => "",
       :query => nil,
       :fragment => nil
-    }
+    })
   end
 
   it "should be identical to its duplicate" do
-    @uri.should == @uri.dup
+    expect(@uri).to eq(@uri.dup)
   end
 
   it "should have an origin of 'http://example.com'" do
-    @uri.origin.should == 'http://example.com'
+    expect(@uri.origin).to eq('http://example.com')
   end
 end
 
@@ -1775,37 +1784,37 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have the correct request URI" do
-    @uri.request_uri.should == "/pub/WWW/TheProject.html"
+    expect(@uri.request_uri).to eq("/pub/WWW/TheProject.html")
   end
 
   it "should have the correct request URI after assignment" do
     @uri.request_uri = "/some/where/else.html?query?string"
-    @uri.request_uri.should == "/some/where/else.html?query?string"
-    @uri.path.should == "/some/where/else.html"
-    @uri.query.should == "query?string"
+    expect(@uri.request_uri).to eq("/some/where/else.html?query?string")
+    expect(@uri.path).to eq("/some/where/else.html")
+    expect(@uri.query).to eq("query?string")
   end
 
   it "should have the correct request URI after assignment" do
     @uri.request_uri = "?x=y"
-    @uri.request_uri.should == "/?x=y"
-    @uri.path.should == "/"
-    @uri.query.should == "x=y"
+    expect(@uri.request_uri).to eq("/?x=y")
+    expect(@uri.path).to eq("/")
+    expect(@uri.query).to eq("x=y")
   end
 
   it "should raise an error if the site value is set to something bogus" do
-    (lambda do
+    expect(lambda do
       @uri.site = 42
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "should raise an error if the request URI is set to something bogus" do
-    (lambda do
+    expect(lambda do
       @uri.request_uri = 42
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "should correctly convert to a hash" do
-    @uri.to_hash.should == {
+    expect(@uri.to_hash).to eq({
       :scheme => "http",
       :user => nil,
       :password => nil,
@@ -1814,11 +1823,11 @@ describe Addressable::URI, "when parsed from " +
       :path => "/pub/WWW/TheProject.html",
       :query => nil,
       :fragment => nil
-    }
+    })
   end
 
   it "should have an origin of 'http://www.w3.org'" do
-    @uri.origin.should == 'http://www.w3.org'
+    expect(@uri.origin).to eq('http://www.w3.org')
   end
 end
 
@@ -1850,31 +1859,39 @@ describe Addressable::URI, "when parsing IPv6 addresses" do
 
   it "should raise an error for " +
       "'http://[<invalid>]/'" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.parse("http://[<invalid>]/")
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 end
 
 describe Addressable::URI, "when parsing IPv6 address" do
   subject { Addressable::URI.parse("http://[3ffe:1900:4545:3:200:f8ff:fe21:67cf]/") }
-  its(:host) { should == '[3ffe:1900:4545:3:200:f8ff:fe21:67cf]' }
-  its(:hostname) { should == '3ffe:1900:4545:3:200:f8ff:fe21:67cf' }
+
+  describe '#host' do
+    subject { super().host }
+    it { is_expected.to eq('[3ffe:1900:4545:3:200:f8ff:fe21:67cf]') }
+  end
+
+  describe '#hostname' do
+    subject { super().hostname }
+    it { is_expected.to eq('3ffe:1900:4545:3:200:f8ff:fe21:67cf') }
+  end
 end
 
 describe Addressable::URI, "when assigning IPv6 address" do
   it "should allow to set bare IPv6 address as hostname" do
     uri = Addressable::URI.parse("http://[::1]/")
     uri.hostname = '3ffe:1900:4545:3:200:f8ff:fe21:67cf'
-    uri.to_s.should == 'http://[3ffe:1900:4545:3:200:f8ff:fe21:67cf]/'
+    expect(uri.to_s).to eq('http://[3ffe:1900:4545:3:200:f8ff:fe21:67cf]/')
   end
 
   it "should not allow to set bare IPv6 address as host" do
     uri = Addressable::URI.parse("http://[::1]/")
-    pending "not checked"
-    (lambda do
+    skip "not checked"
+    expect(lambda do
       uri.host = '3ffe:1900:4545:3:200:f8ff:fe21:67cf'
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 end
 
@@ -1906,9 +1923,9 @@ describe Addressable::URI, "when parsing IPvFuture addresses" do
 
   it "should raise an error for " +
       "'http://[v0.<invalid>]/'" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.parse("http://[v0.<invalid>]/")
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 end
 
@@ -1920,49 +1937,49 @@ describe Addressable::URI, "when parsed from " +
 
   # Based on http://intertwingly.net/blog/2004/07/31/URI-Equivalence
   it "should be equivalent to http://example.com" do
-    @uri.should == Addressable::URI.parse("http://example.com")
+    expect(@uri).to eq(Addressable::URI.parse("http://example.com"))
   end
 
   # Based on http://intertwingly.net/blog/2004/07/31/URI-Equivalence
   it "should be equivalent to HTTP://example.com/" do
-    @uri.should == Addressable::URI.parse("HTTP://example.com/")
+    expect(@uri).to eq(Addressable::URI.parse("HTTP://example.com/"))
   end
 
   # Based on http://intertwingly.net/blog/2004/07/31/URI-Equivalence
   it "should be equivalent to http://example.com:/" do
-    @uri.should == Addressable::URI.parse("http://example.com:/")
+    expect(@uri).to eq(Addressable::URI.parse("http://example.com:/"))
   end
 
   # Based on http://intertwingly.net/blog/2004/07/31/URI-Equivalence
   it "should be equivalent to http://example.com:80/" do
-    @uri.should == Addressable::URI.parse("http://example.com:80/")
+    expect(@uri).to eq(Addressable::URI.parse("http://example.com:80/"))
   end
 
   # Based on http://intertwingly.net/blog/2004/07/31/URI-Equivalence
   it "should be equivalent to http://Example.com/" do
-    @uri.should == Addressable::URI.parse("http://Example.com/")
+    expect(@uri).to eq(Addressable::URI.parse("http://Example.com/"))
   end
 
   it "should have the correct username after assignment" do
     @uri.user = nil
-    @uri.user.should == nil
-    @uri.password.should == nil
-    @uri.to_s.should == "http://example.com/"
+    expect(@uri.user).to eq(nil)
+    expect(@uri.password).to eq(nil)
+    expect(@uri.to_s).to eq("http://example.com/")
   end
 
   it "should have the correct password after assignment" do
     @uri.password = nil
-    @uri.password.should == nil
-    @uri.user.should == nil
-    @uri.to_s.should == "http://example.com/"
+    expect(@uri.password).to eq(nil)
+    expect(@uri.user).to eq(nil)
+    expect(@uri.to_s).to eq("http://example.com/")
   end
 
   it "should have a request URI of '/'" do
-    @uri.request_uri.should == "/"
+    expect(@uri.request_uri).to eq("/")
   end
 
   it "should correctly convert to a hash" do
-    @uri.to_hash.should == {
+    expect(@uri.to_hash).to eq({
       :scheme => "http",
       :user => nil,
       :password => nil,
@@ -1971,63 +1988,63 @@ describe Addressable::URI, "when parsed from " +
       :path => "/",
       :query => nil,
       :fragment => nil
-    }
+    })
   end
 
   it "should be identical to its duplicate" do
-    @uri.should == @uri.dup
+    expect(@uri).to eq(@uri.dup)
   end
 
   it "should have the same hash as its duplicate" do
-    @uri.hash.should == @uri.dup.hash
+    expect(@uri.hash).to eq(@uri.dup.hash)
   end
 
   it "should have a different hash from its equivalent String value" do
-    @uri.hash.should_not == @uri.to_s.hash
+    expect(@uri.hash).not_to eq(@uri.to_s.hash)
   end
 
   it "should have the same hash as an equal URI" do
-    @uri.hash.should == Addressable::URI.parse("http://example.com/").hash
+    expect(@uri.hash).to eq(Addressable::URI.parse("http://example.com/").hash)
   end
 
   it "should be equivalent to http://EXAMPLE.com" do
-    @uri.should == Addressable::URI.parse("http://EXAMPLE.com")
+    expect(@uri).to eq(Addressable::URI.parse("http://EXAMPLE.com"))
   end
 
   it "should be equivalent to http://EXAMPLE.com:80/" do
-    @uri.should == Addressable::URI.parse("http://EXAMPLE.com:80/")
+    expect(@uri).to eq(Addressable::URI.parse("http://EXAMPLE.com:80/"))
   end
 
   it "should have the same hash as http://example.com/" do
-    @uri.hash.should == Addressable::URI.parse("http://example.com/").hash
+    expect(@uri.hash).to eq(Addressable::URI.parse("http://example.com/").hash)
   end
 
   it "should have the same hash as http://example.com after assignment" do
     @uri.path = ""
-    @uri.hash.should == Addressable::URI.parse("http://example.com").hash
+    expect(@uri.hash).to eq(Addressable::URI.parse("http://example.com").hash)
   end
 
   it "should have the same hash as http://example.com/? after assignment" do
     @uri.query = ""
-    @uri.hash.should == Addressable::URI.parse("http://example.com/?").hash
+    expect(@uri.hash).to eq(Addressable::URI.parse("http://example.com/?").hash)
   end
 
   it "should have the same hash as http://example.com/? after assignment" do
     @uri.query_values = {}
-    @uri.hash.should == Addressable::URI.parse("http://example.com/?").hash
+    expect(@uri.hash).to eq(Addressable::URI.parse("http://example.com/?").hash)
   end
 
   it "should have the same hash as http://example.com/# after assignment" do
     @uri.fragment = ""
-    @uri.hash.should == Addressable::URI.parse("http://example.com/#").hash
+    expect(@uri.hash).to eq(Addressable::URI.parse("http://example.com/#").hash)
   end
 
   it "should have a different hash from http://example.com" do
-    @uri.hash.should_not == Addressable::URI.parse("http://example.com").hash
+    expect(@uri.hash).not_to eq(Addressable::URI.parse("http://example.com").hash)
   end
 
   it "should have an origin of 'http://example.com'" do
-    @uri.origin.should == 'http://example.com'
+    expect(@uri.origin).to eq('http://example.com')
   end
 end
 
@@ -2038,7 +2055,7 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should correctly convert to a hash" do
-    @uri.to_hash.should == {
+    expect(@uri.to_hash).to eq({
       :scheme => "http",
       :user => nil,
       :password => nil,
@@ -2047,19 +2064,19 @@ describe Addressable::URI, "when parsed from " +
       :path => "",
       :query => "",
       :fragment => ""
-    }
+    })
   end
 
   it "should have a request URI of '/?'" do
-    @uri.request_uri.should == "/?"
+    expect(@uri.request_uri).to eq("/?")
   end
 
   it "should normalize to 'http://example.com/'" do
-    @uri.normalize.to_s.should == "http://example.com/"
+    expect(@uri.normalize.to_s).to eq("http://example.com/")
   end
 
   it "should have an origin of 'http://example.com'" do
-    @uri.origin.should == "http://example.com"
+    expect(@uri.origin).to eq("http://example.com")
   end
 end
 
@@ -2070,11 +2087,11 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should be equivalent to http://example.com" do
-    @uri.should == Addressable::URI.parse("http://example.com")
+    expect(@uri).to eq(Addressable::URI.parse("http://example.com"))
   end
 
   it "should correctly convert to a hash" do
-    @uri.to_hash.should == {
+    expect(@uri.to_hash).to eq({
       :scheme => "http",
       :user => "",
       :password => nil,
@@ -2083,15 +2100,15 @@ describe Addressable::URI, "when parsed from " +
       :path => "/",
       :query => nil,
       :fragment => nil
-    }
+    })
   end
 
   it "should be identical to its duplicate" do
-    @uri.should == @uri.dup
+    expect(@uri).to eq(@uri.dup)
   end
 
   it "should have an origin of 'http://example.com'" do
-    @uri.origin.should == 'http://example.com'
+    expect(@uri.origin).to eq('http://example.com')
   end
 end
 
@@ -2102,19 +2119,19 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should be equivalent to http://example.com" do
-    @uri.should == Addressable::URI.parse("http://example.com")
+    expect(@uri).to eq(Addressable::URI.parse("http://example.com"))
   end
 
   it "should not be considered to be in normal form" do
-    @uri.normalize.should_not be_eql(@uri)
+    expect(@uri.normalize).not_to be_eql(@uri)
   end
 
   it "should be identical to its duplicate" do
-    @uri.should == @uri.dup
+    expect(@uri).to eq(@uri.dup)
   end
 
   it "should have an origin of 'http://example.com'" do
-    @uri.origin.should == 'http://example.com'
+    expect(@uri.origin).to eq('http://example.com')
   end
 end
 
@@ -2125,11 +2142,11 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should be equivalent to http://example.com" do
-    @uri.should == Addressable::URI.parse("http://example.com")
+    expect(@uri).to eq(Addressable::URI.parse("http://example.com"))
   end
 
   it "should correctly convert to a hash" do
-    @uri.to_hash.should == {
+    expect(@uri.to_hash).to eq({
       :scheme => "http",
       :user => "",
       :password => "",
@@ -2138,15 +2155,15 @@ describe Addressable::URI, "when parsed from " +
       :path => "/",
       :query => nil,
       :fragment => nil
-    }
+    })
   end
 
   it "should be identical to its duplicate" do
-    @uri.should == @uri.dup
+    expect(@uri).to eq(@uri.dup)
   end
 
   it "should have an origin of 'http://example.com'" do
-    @uri.origin.should == 'http://example.com'
+    expect(@uri.origin).to eq('http://example.com')
   end
 end
 
@@ -2158,16 +2175,16 @@ describe Addressable::URI, "when parsed from " +
 
   # Based on http://intertwingly.net/blog/2004/07/31/URI-Equivalence
   it "should be equivalent to http://example.com/%7Esmith/" do
-    @uri.should == Addressable::URI.parse("http://example.com/%7Esmith/")
+    expect(@uri).to eq(Addressable::URI.parse("http://example.com/%7Esmith/"))
   end
 
   # Based on http://intertwingly.net/blog/2004/07/31/URI-Equivalence
   it "should be equivalent to http://example.com/%7esmith/" do
-    @uri.should == Addressable::URI.parse("http://example.com/%7esmith/")
+    expect(@uri).to eq(Addressable::URI.parse("http://example.com/%7esmith/"))
   end
 
   it "should be identical to its duplicate" do
-    @uri.should == @uri.dup
+    expect(@uri).to eq(@uri.dup)
   end
 end
 
@@ -2178,19 +2195,20 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should not raise an exception when normalized" do
-    (lambda do
+    expect(lambda do
       @uri.normalize
-    end).should_not raise_error
+    end).not_to raise_error
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should not change if encoded with the normalizing algorithm" do
-    Addressable::URI.normalized_encode(@uri).to_s.should ==
+    expect(Addressable::URI.normalized_encode(@uri).to_s).to eq(
       "http://example.com/%E8"
-    Addressable::URI.normalized_encode(@uri, Addressable::URI).to_s.should ===
+    )
+    expect(Addressable::URI.normalized_encode(@uri, Addressable::URI).to_s).to be ===
       "http://example.com/%E8"
   end
 end
@@ -2202,22 +2220,23 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should be equal to 'http://example.com/path%2Fsegment/'" do
-    @uri.normalize.should be_eql(
+    expect(@uri.normalize).to be_eql(
       Addressable::URI.parse("http://example.com/path%2Fsegment/")
     )
   end
 
   it "should not be equal to 'http://example.com/path/segment/'" do
-    @uri.should_not ==
+    expect(@uri).not_to eq(
       Addressable::URI.parse("http://example.com/path/segment/")
+    )
   end
 
   it "should not be equal to 'http://example.com/path/segment/'" do
-    @uri.normalize.should_not be_eql(
+    expect(@uri.normalize).not_to be_eql(
       Addressable::URI.parse("http://example.com/path/segment/")
     )
   end
@@ -2230,19 +2249,20 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should not raise an exception when normalized" do
-    (lambda do
+    expect(lambda do
       @uri.normalize
-    end).should_not raise_error
+    end).not_to raise_error
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should not change if encoded with the normalizing algorithm" do
-    Addressable::URI.normalized_encode(@uri).to_s.should ==
+    expect(Addressable::URI.normalized_encode(@uri).to_s).to eq(
       "http://example.com/?%F6"
-    Addressable::URI.normalized_encode(@uri, Addressable::URI).to_s.should ===
+    )
+    expect(Addressable::URI.normalized_encode(@uri, Addressable::URI).to_s).to be ===
       "http://example.com/?%F6"
   end
 end
@@ -2254,19 +2274,20 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should not raise an exception when normalized" do
-    (lambda do
+    expect(lambda do
       @uri.normalize
-    end).should_not raise_error
+    end).not_to raise_error
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should not change if encoded with the normalizing algorithm" do
-    Addressable::URI.normalized_encode(@uri).to_s.should ==
+    expect(Addressable::URI.normalized_encode(@uri).to_s).to eq(
       "http://example.com/#%F6"
-    Addressable::URI.normalized_encode(@uri, Addressable::URI).to_s.should ===
+    )
+    expect(Addressable::URI.normalized_encode(@uri, Addressable::URI).to_s).to be ===
       "http://example.com/#%F6"
   end
 end
@@ -2279,40 +2300,43 @@ describe Addressable::URI, "when parsed from " +
 
   # Based on http://intertwingly.net/blog/2004/07/31/URI-Equivalence
   it "should be equivalent to 'http://example.com/C%CC%A7'" do
-    @uri.should == Addressable::URI.parse("http://example.com/C%CC%A7")
+    expect(@uri).to eq(Addressable::URI.parse("http://example.com/C%CC%A7"))
   end
 
   it "should not change if encoded with the normalizing algorithm" do
-    Addressable::URI.normalized_encode(@uri).to_s.should ==
+    expect(Addressable::URI.normalized_encode(@uri).to_s).to eq(
       "http://example.com/%C3%87"
-    Addressable::URI.normalized_encode(@uri, Addressable::URI).to_s.should ===
+    )
+    expect(Addressable::URI.normalized_encode(@uri, Addressable::URI).to_s).to be ===
       "http://example.com/%C3%87"
   end
 
   it "should raise an error if encoding with an unexpected return type" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.normalized_encode(@uri, Integer)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "if percent encoded should be 'http://example.com/C%25CC%25A7'" do
-    Addressable::URI.encode(@uri).to_s.should ==
+    expect(Addressable::URI.encode(@uri).to_s).to eq(
       "http://example.com/%25C3%2587"
+    )
   end
 
   it "if percent encoded should be 'http://example.com/C%25CC%25A7'" do
-    Addressable::URI.encode(@uri, Addressable::URI).should ==
+    expect(Addressable::URI.encode(@uri, Addressable::URI)).to eq(
       Addressable::URI.parse("http://example.com/%25C3%2587")
+    )
   end
 
   it "should raise an error if encoding with an unexpected return type" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.encode(@uri, Integer)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "should be identical to its duplicate" do
-    @uri.should == @uri.dup
+    expect(@uri).to eq(@uri.dup)
   end
 end
 
@@ -2323,55 +2347,55 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'http' scheme" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "should have an authority segment of 'example.com'" do
-    @uri.authority.should == "example.com"
+    expect(@uri.authority).to eq("example.com")
   end
 
   it "should have a host of 'example.com'" do
-    @uri.host.should == "example.com"
+    expect(@uri.host).to eq("example.com")
   end
 
   it "should have no username" do
-    @uri.user.should == nil
+    expect(@uri.user).to eq(nil)
   end
 
   it "should have no password" do
-    @uri.password.should == nil
+    expect(@uri.password).to eq(nil)
   end
 
   it "should use port 80" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should have a path of '/'" do
-    @uri.path.should == "/"
+    expect(@uri.path).to eq("/")
   end
 
   it "should have a query string of 'q=string'" do
-    @uri.query.should == "q=string"
+    expect(@uri.query).to eq("q=string")
   end
 
   it "should have no fragment" do
-    @uri.fragment.should == nil
+    expect(@uri.fragment).to eq(nil)
   end
 
   it "should be considered absolute" do
-    @uri.should be_absolute
+    expect(@uri).to be_absolute
   end
 
   it "should not be considered relative" do
-    @uri.should_not be_relative
+    expect(@uri).not_to be_relative
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should be identical to its duplicate" do
-    @uri.should == @uri.dup
+    expect(@uri).to eq(@uri.dup)
   end
 end
 
@@ -2382,99 +2406,99 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'http' scheme" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "should have an authority segment of 'example.com:80'" do
-    @uri.authority.should == "example.com:80"
+    expect(@uri.authority).to eq("example.com:80")
   end
 
   it "should have a host of 'example.com'" do
-    @uri.host.should == "example.com"
+    expect(@uri.host).to eq("example.com")
   end
 
   it "should have no username" do
-    @uri.user.should == nil
+    expect(@uri.user).to eq(nil)
   end
 
   it "should have no password" do
-    @uri.password.should == nil
+    expect(@uri.password).to eq(nil)
   end
 
   it "should use port 80" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should have explicit port 80" do
-    @uri.port.should == 80
+    expect(@uri.port).to eq(80)
   end
 
   it "should have a path of '/'" do
-    @uri.path.should == "/"
+    expect(@uri.path).to eq("/")
   end
 
   it "should have no query string" do
-    @uri.query.should == nil
+    expect(@uri.query).to eq(nil)
   end
 
   it "should have no fragment" do
-    @uri.fragment.should == nil
+    expect(@uri.fragment).to eq(nil)
   end
 
   it "should be considered absolute" do
-    @uri.should be_absolute
+    expect(@uri).to be_absolute
   end
 
   it "should not be considered relative" do
-    @uri.should_not be_relative
+    expect(@uri).not_to be_relative
   end
 
   it "should be exactly equal to http://example.com:80/" do
-    @uri.eql?(Addressable::URI.parse("http://example.com:80/")).should == true
+    expect(@uri.eql?(Addressable::URI.parse("http://example.com:80/"))).to eq(true)
   end
 
   it "should be roughly equal to http://example.com/" do
-    (@uri === Addressable::URI.parse("http://example.com/")).should == true
+    expect(@uri === Addressable::URI.parse("http://example.com/")).to eq(true)
   end
 
   it "should be roughly equal to the string 'http://example.com/'" do
-    (@uri === "http://example.com/").should == true
+    expect(@uri === "http://example.com/").to eq(true)
   end
 
   it "should not be roughly equal to the string " +
       "'http://example.com:bogus/'" do
-    (lambda do
-      (@uri === "http://example.com:bogus/").should == false
-    end).should_not raise_error
+    expect(lambda do
+      expect(@uri === "http://example.com:bogus/").to eq(false)
+    end).not_to raise_error
   end
 
   it "should result in itself when joined with itself" do
-    @uri.join(@uri).to_s.should == "http://example.com:80/"
-    @uri.join!(@uri).to_s.should == "http://example.com:80/"
+    expect(@uri.join(@uri).to_s).to eq("http://example.com:80/")
+    expect(@uri.join!(@uri).to_s).to eq("http://example.com:80/")
   end
 
   # Section 6.2.3 of RFC 3986
   it "should be equal to http://example.com/" do
-    @uri.should == Addressable::URI.parse("http://example.com/")
+    expect(@uri).to eq(Addressable::URI.parse("http://example.com/"))
   end
 
   # Section 6.2.3 of RFC 3986
   it "should be equal to http://example.com:/" do
-    @uri.should == Addressable::URI.parse("http://example.com:/")
+    expect(@uri).to eq(Addressable::URI.parse("http://example.com:/"))
   end
 
   # Section 6.2.3 of RFC 3986
   it "should be equal to http://example.com:80/" do
-    @uri.should == Addressable::URI.parse("http://example.com:80/")
+    expect(@uri).to eq(Addressable::URI.parse("http://example.com:80/"))
   end
 
   # Section 6.2.2.1 of RFC 3986
   it "should be equal to http://EXAMPLE.COM/" do
-    @uri.should == Addressable::URI.parse("http://EXAMPLE.COM/")
+    expect(@uri).to eq(Addressable::URI.parse("http://EXAMPLE.COM/"))
   end
 
   it "should correctly convert to a hash" do
-    @uri.to_hash.should == {
+    expect(@uri.to_hash).to eq({
       :scheme => "http",
       :user => nil,
       :password => nil,
@@ -2483,21 +2507,22 @@ describe Addressable::URI, "when parsed from " +
       :path => "/",
       :query => nil,
       :fragment => nil
-    }
+    })
   end
 
   it "should be identical to its duplicate" do
-    @uri.should == @uri.dup
+    expect(@uri).to eq(@uri.dup)
   end
 
   it "should have an origin of 'http://example.com'" do
-    @uri.origin.should == 'http://example.com'
+    expect(@uri.origin).to eq('http://example.com')
   end
 
   it "should not change if encoded with the normalizing algorithm" do
-    Addressable::URI.normalized_encode(@uri).to_s.should ==
+    expect(Addressable::URI.normalized_encode(@uri).to_s).to eq(
       "http://example.com:80/"
-    Addressable::URI.normalized_encode(@uri, Addressable::URI).to_s.should ===
+    )
+    expect(Addressable::URI.normalized_encode(@uri, Addressable::URI).to_s).to be ===
       "http://example.com:80/"
   end
 end
@@ -2509,88 +2534,92 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'http' scheme" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "should have an authority segment of 'example.com:8080'" do
-    @uri.authority.should == "example.com:8080"
+    expect(@uri.authority).to eq("example.com:8080")
   end
 
   it "should have a host of 'example.com'" do
-    @uri.host.should == "example.com"
+    expect(@uri.host).to eq("example.com")
   end
 
   it "should have no username" do
-    @uri.user.should == nil
+    expect(@uri.user).to eq(nil)
   end
 
   it "should have no password" do
-    @uri.password.should == nil
+    expect(@uri.password).to eq(nil)
   end
 
   it "should use port 8080" do
-    @uri.inferred_port.should == 8080
+    expect(@uri.inferred_port).to eq(8080)
   end
 
   it "should have explicit port 8080" do
-    @uri.port.should == 8080
+    expect(@uri.port).to eq(8080)
   end
 
   it "should have default port 80" do
-    @uri.default_port.should == 80
+    expect(@uri.default_port).to eq(80)
   end
 
   it "should have a path of '/'" do
-    @uri.path.should == "/"
+    expect(@uri.path).to eq("/")
   end
 
   it "should have no query string" do
-    @uri.query.should == nil
+    expect(@uri.query).to eq(nil)
   end
 
   it "should have no fragment" do
-    @uri.fragment.should == nil
+    expect(@uri.fragment).to eq(nil)
   end
 
   it "should be considered absolute" do
-    @uri.should be_absolute
+    expect(@uri).to be_absolute
   end
 
   it "should not be considered relative" do
-    @uri.should_not be_relative
+    expect(@uri).not_to be_relative
   end
 
   it "should be exactly equal to http://example.com:8080/" do
-    @uri.eql?(Addressable::URI.parse(
-      "http://example.com:8080/")).should == true
+    expect(@uri.eql?(Addressable::URI.parse(
+      "http://example.com:8080/"))).to eq(true)
   end
 
   it "should have a route of 'http://example.com:8080/' from " +
       "'http://example.com/path/to/'" do
-    @uri.route_from("http://example.com/path/to/").should ==
+    expect(@uri.route_from("http://example.com/path/to/")).to eq(
       Addressable::URI.parse("http://example.com:8080/")
+    )
   end
 
   it "should have a route of 'http://example.com:8080/' from " +
       "'http://example.com:80/path/to/'" do
-    @uri.route_from("http://example.com:80/path/to/").should ==
+    expect(@uri.route_from("http://example.com:80/path/to/")).to eq(
       Addressable::URI.parse("http://example.com:8080/")
+    )
   end
 
   it "should have a route of '../../' from " +
       "'http://example.com:8080/path/to/'" do
-    @uri.route_from("http://example.com:8080/path/to/").should ==
+    expect(@uri.route_from("http://example.com:8080/path/to/")).to eq(
       Addressable::URI.parse("../../")
+    )
   end
 
   it "should have a route of 'http://example.com:8080/' from " +
       "'http://user:pass@example.com/path/to/'" do
-    @uri.route_from("http://user:pass@example.com/path/to/").should ==
+    expect(@uri.route_from("http://user:pass@example.com/path/to/")).to eq(
       Addressable::URI.parse("http://example.com:8080/")
+    )
   end
 
   it "should correctly convert to a hash" do
-    @uri.to_hash.should == {
+    expect(@uri.to_hash).to eq({
       :scheme => "http",
       :user => nil,
       :password => nil,
@@ -2599,21 +2628,22 @@ describe Addressable::URI, "when parsed from " +
       :path => "/",
       :query => nil,
       :fragment => nil
-    }
+    })
   end
 
   it "should be identical to its duplicate" do
-    @uri.should == @uri.dup
+    expect(@uri).to eq(@uri.dup)
   end
 
   it "should have an origin of 'http://example.com:8080'" do
-    @uri.origin.should == 'http://example.com:8080'
+    expect(@uri.origin).to eq('http://example.com:8080')
   end
 
   it "should not change if encoded with the normalizing algorithm" do
-    Addressable::URI.normalized_encode(@uri).to_s.should ==
+    expect(Addressable::URI.normalized_encode(@uri).to_s).to eq(
       "http://example.com:8080/"
-    Addressable::URI.normalized_encode(@uri, Addressable::URI).to_s.should ===
+    )
+    expect(Addressable::URI.normalized_encode(@uri, Addressable::URI).to_s).to be ===
       "http://example.com:8080/"
   end
 end
@@ -2625,19 +2655,19 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have the correct port" do
-    @uri.port.should == 80
+    expect(@uri.port).to eq(80)
   end
 
   it "should not be considered to be in normal form" do
-    @uri.normalize.should_not be_eql(@uri)
+    expect(@uri.normalize).not_to be_eql(@uri)
   end
 
   it "should normalize to 'http://example.com/'" do
-    @uri.normalize.to_s.should == "http://example.com/"
+    expect(@uri.normalize.to_s).to eq("http://example.com/")
   end
 
   it "should have an origin of 'http://example.com'" do
-    @uri.origin.should == 'http://example.com'
+    expect(@uri.origin).to eq('http://example.com')
   end
 end
 
@@ -2648,21 +2678,19 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should be considered to be in normal form" do
-    pending(
+    skip(
       'path segment normalization should happen before ' +
       'percent escaping normalization'
-    ) do
-      @uri.normalize.should be_eql(@uri)
-    end
+    )
+    @uri.normalize.should be_eql(@uri)
   end
 
   it "should normalize to 'http://example.com/%2E/'" do
-    pending(
+    skip(
       'path segment normalization should happen before ' +
       'percent escaping normalization'
-    ) do
-      @uri.normalize.should == "http://example.com/%2E/"
-    end
+    )
+    expect(@uri.normalize).to eq("http://example.com/%2E/")
   end
 end
 
@@ -2673,15 +2701,15 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have the correct port" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should not be considered to be in normal form" do
-    @uri.normalize.should_not be_eql(@uri)
+    expect(@uri.normalize).not_to be_eql(@uri)
   end
 
   it "should normalize to 'http://example.com/'" do
-    @uri.normalize.to_s.should == "http://example.com/"
+    expect(@uri.normalize.to_s).to eq("http://example.com/")
   end
 end
 
@@ -2692,15 +2720,15 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have the correct port" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should not be considered to be in normal form" do
-    @uri.normalize.should_not be_eql(@uri)
+    expect(@uri.normalize).not_to be_eql(@uri)
   end
 
   it "should normalize to 'http://example.com/'" do
-    @uri.normalize.to_s.should == "http://example.com/"
+    expect(@uri.normalize.to_s).to eq("http://example.com/")
   end
 end
 
@@ -2711,15 +2739,15 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have the correct port" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should not be considered to be in normal form" do
-    @uri.normalize.should_not be_eql(@uri)
+    expect(@uri.normalize).not_to be_eql(@uri)
   end
 
   it "should normalize to 'http://example.com/'" do
-    @uri.normalize.to_s.should == "http://example.com/"
+    expect(@uri.normalize.to_s).to eq("http://example.com/")
   end
 end
 
@@ -2730,15 +2758,15 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have the correct port" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should not be considered to be in normal form" do
-    @uri.normalize.should_not be_eql(@uri)
+    expect(@uri.normalize).not_to be_eql(@uri)
   end
 
   it "should normalize to 'http://example.com/'" do
-    @uri.normalize.to_s.should == "http://example.com/"
+    expect(@uri.normalize.to_s).to eq("http://example.com/")
   end
 end
 
@@ -2749,15 +2777,15 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have the correct port" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should not be considered to be in normal form" do
-    @uri.normalize.should_not be_eql(@uri)
+    expect(@uri.normalize).not_to be_eql(@uri)
   end
 
   it "should normalize to 'http://example.com/'" do
-    @uri.normalize.to_s.should == "http://example.com/"
+    expect(@uri.normalize.to_s).to eq("http://example.com/")
   end
 end
 
@@ -2768,15 +2796,15 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have the correct port" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should not be considered to be in normal form" do
-    @uri.normalize.should_not be_eql(@uri)
+    expect(@uri.normalize).not_to be_eql(@uri)
   end
 
   it "should normalize to 'http://example.com/'" do
-    @uri.normalize.to_s.should == "http://example.com/"
+    expect(@uri.normalize.to_s).to eq("http://example.com/")
   end
 end
 
@@ -2786,12 +2814,12 @@ describe Addressable::URI, "when parsed from '/a/b/c/./../../g'" do
   end
 
   it "should not be considered to be in normal form" do
-    @uri.normalize.should_not be_eql(@uri)
+    expect(@uri.normalize).not_to be_eql(@uri)
   end
 
   # Section 5.2.4 of RFC 3986
   it "should normalize to '/a/g'" do
-    @uri.normalize.to_s.should == "/a/g"
+    expect(@uri.normalize.to_s).to eq("/a/g")
   end
 end
 
@@ -2801,12 +2829,12 @@ describe Addressable::URI, "when parsed from 'mid/content=5/../6'" do
   end
 
   it "should not be considered to be in normal form" do
-    @uri.normalize.should_not be_eql(@uri)
+    expect(@uri.normalize).not_to be_eql(@uri)
   end
 
   # Section 5.2.4 of RFC 3986
   it "should normalize to 'mid/6'" do
-    @uri.normalize.to_s.should == "mid/6"
+    expect(@uri.normalize.to_s).to eq("mid/6")
   end
 end
 
@@ -2817,11 +2845,11 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should not be considered to be in normal form" do
-    @uri.normalize.should_not be_eql(@uri)
+    expect(@uri.normalize).not_to be_eql(@uri)
   end
 
   it "should normalize to 'http://www.example.com//'" do
-    @uri.normalize.to_s.should == "http://www.example.com//"
+    expect(@uri.normalize.to_s).to eq("http://www.example.com//")
   end
 end
 
@@ -2832,105 +2860,113 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'http' scheme" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "should have an authority segment of 'example.com'" do
-    @uri.authority.should == "example.com"
+    expect(@uri.authority).to eq("example.com")
   end
 
   it "should have a host of 'example.com'" do
-    @uri.host.should == "example.com"
+    expect(@uri.host).to eq("example.com")
   end
 
   it "should have no username" do
-    @uri.user.should == nil
+    expect(@uri.user).to eq(nil)
   end
 
   it "should have no password" do
-    @uri.password.should == nil
+    expect(@uri.password).to eq(nil)
   end
 
   it "should use port 80" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should have a path of '/path/to/resource/'" do
-    @uri.path.should == "/path/to/resource/"
+    expect(@uri.path).to eq("/path/to/resource/")
   end
 
   it "should have no query string" do
-    @uri.query.should == nil
+    expect(@uri.query).to eq(nil)
   end
 
   it "should have no fragment" do
-    @uri.fragment.should == nil
+    expect(@uri.fragment).to eq(nil)
   end
 
   it "should be considered absolute" do
-    @uri.should be_absolute
+    expect(@uri).to be_absolute
   end
 
   it "should not be considered relative" do
-    @uri.should_not be_relative
+    expect(@uri).not_to be_relative
   end
 
   it "should be exactly equal to http://example.com:8080/" do
-    @uri.eql?(Addressable::URI.parse(
-      "http://example.com/path/to/resource/")).should == true
+    expect(@uri.eql?(Addressable::URI.parse(
+      "http://example.com/path/to/resource/"))).to eq(true)
   end
 
   it "should have a route of 'resource/' from " +
       "'http://example.com/path/to/'" do
-    @uri.route_from("http://example.com/path/to/").should ==
+    expect(@uri.route_from("http://example.com/path/to/")).to eq(
       Addressable::URI.parse("resource/")
+    )
   end
 
   it "should have a route of '../' from " +
     "'http://example.com/path/to/resource/sub'" do
-    @uri.route_from("http://example.com/path/to/resource/sub").should ==
+    expect(@uri.route_from("http://example.com/path/to/resource/sub")).to eq(
       Addressable::URI.parse("../")
+    )
   end
 
 
   it "should have a route of 'resource/' from " +
     "'http://example.com/path/to/another'" do
-    @uri.route_from("http://example.com/path/to/another").should ==
+    expect(@uri.route_from("http://example.com/path/to/another")).to eq(
       Addressable::URI.parse("resource/")
+    )
   end
 
   it "should have a route of 'resource/' from " +
       "'http://example.com/path/to/res'" do
-    @uri.route_from("http://example.com/path/to/res").should ==
+    expect(@uri.route_from("http://example.com/path/to/res")).to eq(
       Addressable::URI.parse("resource/")
+    )
   end
 
   it "should have a route of 'resource/' from " +
       "'http://example.com:80/path/to/'" do
-    @uri.route_from("http://example.com:80/path/to/").should ==
+    expect(@uri.route_from("http://example.com:80/path/to/")).to eq(
       Addressable::URI.parse("resource/")
+    )
   end
 
   it "should have a route of 'http://example.com/path/to/' from " +
       "'http://example.com:8080/path/to/'" do
-    @uri.route_from("http://example.com:8080/path/to/").should ==
+    expect(@uri.route_from("http://example.com:8080/path/to/")).to eq(
       Addressable::URI.parse("http://example.com/path/to/resource/")
+    )
   end
 
   it "should have a route of 'http://example.com/path/to/' from " +
       "'http://user:pass@example.com/path/to/'" do
-    @uri.route_from("http://user:pass@example.com/path/to/").should ==
+    expect(@uri.route_from("http://user:pass@example.com/path/to/")).to eq(
       Addressable::URI.parse("http://example.com/path/to/resource/")
+    )
   end
 
   it "should have a route of '../../path/to/resource/' from " +
       "'http://example.com/to/resource/'" do
-    @uri.route_from("http://example.com/to/resource/").should ==
+    expect(@uri.route_from("http://example.com/to/resource/")).to eq(
       Addressable::URI.parse("../../path/to/resource/")
+    )
   end
 
   it "should correctly convert to a hash" do
-    @uri.to_hash.should == {
+    expect(@uri.to_hash).to eq({
       :scheme => "http",
       :user => nil,
       :password => nil,
@@ -2939,11 +2975,11 @@ describe Addressable::URI, "when parsed from " +
       :path => "/path/to/resource/",
       :query => nil,
       :fragment => nil
-    }
+    })
   end
 
   it "should be identical to its duplicate" do
-    @uri.should == @uri.dup
+    expect(@uri).to eq(@uri.dup)
   end
 end
 
@@ -2954,70 +2990,71 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should not have a scheme" do
-    @uri.scheme.should == nil
+    expect(@uri.scheme).to eq(nil)
   end
 
   it "should not be considered ip-based" do
-    @uri.should_not be_ip_based
+    expect(@uri).not_to be_ip_based
   end
 
   it "should not have an authority segment" do
-    @uri.authority.should == nil
+    expect(@uri.authority).to eq(nil)
   end
 
   it "should not have a host" do
-    @uri.host.should == nil
+    expect(@uri.host).to eq(nil)
   end
 
   it "should have no username" do
-    @uri.user.should == nil
+    expect(@uri.user).to eq(nil)
   end
 
   it "should have no password" do
-    @uri.password.should == nil
+    expect(@uri.password).to eq(nil)
   end
 
   it "should not have a port" do
-    @uri.port.should == nil
+    expect(@uri.port).to eq(nil)
   end
 
   it "should have a path of 'relative/path/to/resource'" do
-    @uri.path.should == "relative/path/to/resource"
+    expect(@uri.path).to eq("relative/path/to/resource")
   end
 
   it "should have no query string" do
-    @uri.query.should == nil
+    expect(@uri.query).to eq(nil)
   end
 
   it "should have no fragment" do
-    @uri.fragment.should == nil
+    expect(@uri.fragment).to eq(nil)
   end
 
   it "should not be considered absolute" do
-    @uri.should_not be_absolute
+    expect(@uri).not_to be_absolute
   end
 
   it "should be considered relative" do
-    @uri.should be_relative
+    expect(@uri).to be_relative
   end
 
   it "should raise an error if routing is attempted" do
-    (lambda do
+    expect(lambda do
       @uri.route_to("http://example.com/")
-    end).should raise_error(ArgumentError, /relative\/path\/to\/resource/)
-    (lambda do
+    end).to raise_error(ArgumentError, /relative\/path\/to\/resource/)
+    expect(lambda do
       @uri.route_from("http://example.com/")
-    end).should raise_error(ArgumentError, /relative\/path\/to\/resource/)
+    end).to raise_error(ArgumentError, /relative\/path\/to\/resource/)
   end
 
   it "when joined with 'another/relative/path' should be " +
       "'relative/path/to/another/relative/path'" do
-    @uri.join('another/relative/path').should ==
+    expect(@uri.join('another/relative/path')).to eq(
       Addressable::URI.parse("relative/path/to/another/relative/path")
+    )
   end
 
   it "should be identical to its duplicate" do
-    @uri.should == @uri.dup
+    expect(@uri).to eq(@uri.dup)
   end
 end
 
@@ -3028,57 +3065,58 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should not have a scheme" do
-    @uri.scheme.should == nil
+    expect(@uri.scheme).to eq(nil)
   end
 
   it "should not be considered ip-based" do
-    @uri.should_not be_ip_based
+    expect(@uri).not_to be_ip_based
   end
 
   it "should not have an authority segment" do
-    @uri.authority.should == nil
+    expect(@uri.authority).to eq(nil)
   end
 
   it "should not have a host" do
-    @uri.host.should == nil
+    expect(@uri.host).to eq(nil)
   end
 
   it "should have no username" do
-    @uri.user.should == nil
+    expect(@uri.user).to eq(nil)
   end
 
   it "should have no password" do
-    @uri.password.should == nil
+    expect(@uri.password).to eq(nil)
   end
 
   it "should not have a port" do
-    @uri.port.should == nil
+    expect(@uri.port).to eq(nil)
   end
 
   it "should have a path of 'relative_path_with_no_slashes'" do
-    @uri.path.should == "relative_path_with_no_slashes"
+    expect(@uri.path).to eq("relative_path_with_no_slashes")
   end
 
   it "should have no query string" do
-    @uri.query.should == nil
+    expect(@uri.query).to eq(nil)
   end
 
   it "should have no fragment" do
-    @uri.fragment.should == nil
+    expect(@uri.fragment).to eq(nil)
   end
 
   it "should not be considered absolute" do
-    @uri.should_not be_absolute
+    expect(@uri).not_to be_absolute
   end
 
   it "should be considered relative" do
-    @uri.should be_relative
+    expect(@uri).to be_relative
   end
 
   it "when joined with 'another_relative_path' should be " +
       "'another_relative_path'" do
-    @uri.join('another_relative_path').should ==
+    expect(@uri.join('another_relative_path')).to eq(
       Addressable::URI.parse("another_relative_path")
+    )
   end
 end
 
@@ -3089,47 +3127,47 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a scheme of 'http'" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "should have an authority segment of 'example.com'" do
-    @uri.authority.should == "example.com"
+    expect(@uri.authority).to eq("example.com")
   end
 
   it "should have a host of 'example.com'" do
-    @uri.host.should == "example.com"
+    expect(@uri.host).to eq("example.com")
   end
 
   it "should have no username" do
-    @uri.user.should == nil
+    expect(@uri.user).to eq(nil)
   end
 
   it "should have no password" do
-    @uri.password.should == nil
+    expect(@uri.password).to eq(nil)
   end
 
   it "should use port 80" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should have a path of '/file.txt'" do
-    @uri.path.should == "/file.txt"
+    expect(@uri.path).to eq("/file.txt")
   end
 
   it "should have a basename of 'file.txt'" do
-    @uri.basename.should == "file.txt"
+    expect(@uri.basename).to eq("file.txt")
   end
 
   it "should have an extname of '.txt'" do
-    @uri.extname.should == ".txt"
+    expect(@uri.extname).to eq(".txt")
   end
 
   it "should have no query string" do
-    @uri.query.should == nil
+    expect(@uri.query).to eq(nil)
   end
 
   it "should have no fragment" do
-    @uri.fragment.should == nil
+    expect(@uri.fragment).to eq(nil)
   end
 end
 
@@ -3140,47 +3178,47 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a scheme of 'http'" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "should have an authority segment of 'example.com'" do
-    @uri.authority.should == "example.com"
+    expect(@uri.authority).to eq("example.com")
   end
 
   it "should have a host of 'example.com'" do
-    @uri.host.should == "example.com"
+    expect(@uri.host).to eq("example.com")
   end
 
   it "should have no username" do
-    @uri.user.should == nil
+    expect(@uri.user).to eq(nil)
   end
 
   it "should have no password" do
-    @uri.password.should == nil
+    expect(@uri.password).to eq(nil)
   end
 
   it "should use port 80" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should have a path of '/file.txt;parameter'" do
-    @uri.path.should == "/file.txt;parameter"
+    expect(@uri.path).to eq("/file.txt;parameter")
   end
 
   it "should have a basename of 'file.txt'" do
-    @uri.basename.should == "file.txt"
+    expect(@uri.basename).to eq("file.txt")
   end
 
   it "should have an extname of '.txt'" do
-    @uri.extname.should == ".txt"
+    expect(@uri.extname).to eq(".txt")
   end
 
   it "should have no query string" do
-    @uri.query.should == nil
+    expect(@uri.query).to eq(nil)
   end
 
   it "should have no fragment" do
-    @uri.fragment.should == nil
+    expect(@uri.fragment).to eq(nil)
   end
 end
 
@@ -3191,51 +3229,51 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a scheme of 'http'" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "should have a scheme of 'http'" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "should have an authority segment of 'example.com'" do
-    @uri.authority.should == "example.com"
+    expect(@uri.authority).to eq("example.com")
   end
 
   it "should have a host of 'example.com'" do
-    @uri.host.should == "example.com"
+    expect(@uri.host).to eq("example.com")
   end
 
   it "should have no username" do
-    @uri.user.should == nil
+    expect(@uri.user).to eq(nil)
   end
 
   it "should have no password" do
-    @uri.password.should == nil
+    expect(@uri.password).to eq(nil)
   end
 
   it "should use port 80" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should have a path of '/file.txt;x=y'" do
-    @uri.path.should == "/file.txt;x=y"
+    expect(@uri.path).to eq("/file.txt;x=y")
   end
 
   it "should have an extname of '.txt'" do
-    @uri.extname.should == ".txt"
+    expect(@uri.extname).to eq(".txt")
   end
 
   it "should have no query string" do
-    @uri.query.should == nil
+    expect(@uri.query).to eq(nil)
   end
 
   it "should have no fragment" do
-    @uri.fragment.should == nil
+    expect(@uri.fragment).to eq(nil)
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 end
 
@@ -3248,27 +3286,27 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a scheme of 'svn+ssh'" do
-    @uri.scheme.should == "svn+ssh"
+    expect(@uri.scheme).to eq("svn+ssh")
   end
 
   it "should be considered to be ip-based" do
-    @uri.should be_ip_based
+    expect(@uri).to be_ip_based
   end
 
   it "should have a path of '/var/svn/project'" do
-    @uri.path.should == "/var/svn/project"
+    expect(@uri.path).to eq("/var/svn/project")
   end
 
   it "should have a username of 'developername'" do
-    @uri.user.should == "developername"
+    expect(@uri.user).to eq("developername")
   end
 
   it "should have no password" do
-    @uri.password.should == nil
+    expect(@uri.password).to eq(nil)
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 end
 
@@ -3281,35 +3319,35 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a scheme of 'ssh+svn'" do
-    @uri.scheme.should == "ssh+svn"
+    expect(@uri.scheme).to eq("ssh+svn")
   end
 
   it "should have a normalized scheme of 'svn+ssh'" do
-    @uri.normalized_scheme.should == "svn+ssh"
+    expect(@uri.normalized_scheme).to eq("svn+ssh")
   end
 
   it "should have a normalized site of 'svn+ssh'" do
-    @uri.normalized_site.should == "svn+ssh://developername@rubyforge.org"
+    expect(@uri.normalized_site).to eq("svn+ssh://developername@rubyforge.org")
   end
 
   it "should not be considered to be ip-based" do
-    @uri.should_not be_ip_based
+    expect(@uri).not_to be_ip_based
   end
 
   it "should have a path of '/var/svn/project'" do
-    @uri.path.should == "/var/svn/project"
+    expect(@uri.path).to eq("/var/svn/project")
   end
 
   it "should have a username of 'developername'" do
-    @uri.user.should == "developername"
+    expect(@uri.user).to eq("developername")
   end
 
   it "should have no password" do
-    @uri.password.should == nil
+    expect(@uri.password).to eq(nil)
   end
 
   it "should not be considered to be in normal form" do
-    @uri.normalize.should_not be_eql(@uri)
+    expect(@uri.normalize).not_to be_eql(@uri)
   end
 end
 
@@ -3320,23 +3358,23 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a scheme of 'mailto'" do
-    @uri.scheme.should == "mailto"
+    expect(@uri.scheme).to eq("mailto")
   end
 
   it "should not be considered to be ip-based" do
-    @uri.should_not be_ip_based
+    expect(@uri).not_to be_ip_based
   end
 
   it "should have a path of 'user@example.com'" do
-    @uri.path.should == "user@example.com"
+    expect(@uri.path).to eq("user@example.com")
   end
 
   it "should have no user" do
-    @uri.user.should == nil
+    expect(@uri.user).to eq(nil)
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 end
 
@@ -3348,28 +3386,28 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a scheme of 'tag'" do
-    @uri.scheme.should == "tag"
+    expect(@uri.scheme).to eq("tag")
   end
 
   it "should be considered to be ip-based" do
-    @uri.should_not be_ip_based
+    expect(@uri).not_to be_ip_based
   end
 
   it "should have a path of " +
       "'example.com,2006-08-18:/path/to/something'" do
-    @uri.path.should == "example.com,2006-08-18:/path/to/something"
+    expect(@uri.path).to eq("example.com,2006-08-18:/path/to/something")
   end
 
   it "should have no user" do
-    @uri.user.should == nil
+    expect(@uri.user).to eq(nil)
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should have a 'null' origin" do
-    @uri.origin.should == 'null'
+    expect(@uri.origin).to eq('null')
   end
 end
 
@@ -3380,7 +3418,7 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 end
 
@@ -3391,7 +3429,7 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 end
 
@@ -3402,19 +3440,19 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a scheme of 'view-source'" do
-    @uri.scheme.should == "view-source"
+    expect(@uri.scheme).to eq("view-source")
   end
 
   it "should have a path of 'http://example.com/'" do
-    @uri.path.should == "http://example.com/"
+    expect(@uri.path).to eq("http://example.com/")
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should have a 'null' origin" do
-    @uri.origin.should == 'null'
+    expect(@uri.origin).to eq('null')
   end
 end
 
@@ -3426,340 +3464,368 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'http' scheme" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "should have an authority segment of 'user:pass@example.com'" do
-    @uri.authority.should == "user:pass@example.com"
+    expect(@uri.authority).to eq("user:pass@example.com")
   end
 
   it "should have a username of 'user'" do
-    @uri.user.should == "user"
+    expect(@uri.user).to eq("user")
   end
 
   it "should have a password of 'pass'" do
-    @uri.password.should == "pass"
+    expect(@uri.password).to eq("pass")
   end
 
   it "should have a host of 'example.com'" do
-    @uri.host.should == "example.com"
+    expect(@uri.host).to eq("example.com")
   end
 
   it "should use port 80" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should have a path of '/path/to/resource'" do
-    @uri.path.should == "/path/to/resource"
+    expect(@uri.path).to eq("/path/to/resource")
   end
 
   it "should have a query string of 'query=x'" do
-    @uri.query.should == "query=x"
+    expect(@uri.query).to eq("query=x")
   end
 
   it "should have a fragment of 'fragment'" do
-    @uri.fragment.should == "fragment"
+    expect(@uri.fragment).to eq("fragment")
   end
 
   it "should be considered to be in normal form" do
-    @uri.normalize.should be_eql(@uri)
+    expect(@uri.normalize).to be_eql(@uri)
   end
 
   it "should have a route of '../../' to " +
       "'http://user:pass@example.com/path/'" do
-    @uri.route_to("http://user:pass@example.com/path/").should ==
+    expect(@uri.route_to("http://user:pass@example.com/path/")).to eq(
       Addressable::URI.parse("../../")
+    )
   end
 
   it "should have a route of 'to/resource?query=x#fragment' " +
       "from 'http://user:pass@example.com/path/'" do
-    @uri.route_from("http://user:pass@example.com/path/").should ==
+    expect(@uri.route_from("http://user:pass@example.com/path/")).to eq(
       Addressable::URI.parse("to/resource?query=x#fragment")
+    )
   end
 
   it "should have a route of '?query=x#fragment' " +
       "from 'http://user:pass@example.com/path/to/resource'" do
-    @uri.route_from("http://user:pass@example.com/path/to/resource").should ==
+    expect(@uri.route_from("http://user:pass@example.com/path/to/resource")).to eq(
       Addressable::URI.parse("?query=x#fragment")
+    )
   end
 
   it "should have a route of '#fragment' " +
       "from 'http://user:pass@example.com/path/to/resource?query=x'" do
-    @uri.route_from(
-      "http://user:pass@example.com/path/to/resource?query=x").should ==
+    expect(@uri.route_from(
+      "http://user:pass@example.com/path/to/resource?query=x")).to eq(
         Addressable::URI.parse("#fragment")
+    )
   end
 
   it "should have a route of '#fragment' from " +
       "'http://user:pass@example.com/path/to/resource?query=x#fragment'" do
-    @uri.route_from(
+    expect(@uri.route_from(
       "http://user:pass@example.com/path/to/resource?query=x#fragment"
-    ).should == Addressable::URI.parse("#fragment")
+    )).to eq(Addressable::URI.parse("#fragment"))
   end
 
   it "should have a route of 'http://elsewhere.com/' to " +
       "'http://elsewhere.com/'" do
-    @uri.route_to("http://elsewhere.com/").should ==
+    expect(@uri.route_to("http://elsewhere.com/")).to eq(
       Addressable::URI.parse("http://elsewhere.com/")
+    )
   end
 
   it "should have a route of " +
       "'http://user:pass@example.com/path/to/resource?query=x#fragment' " +
       "from 'http://example.com/path/to/'" do
-    @uri.route_from("http://elsewhere.com/path/to/").should ==
+    expect(@uri.route_from("http://elsewhere.com/path/to/")).to eq(
       Addressable::URI.parse(
         "http://user:pass@example.com/path/to/resource?query=x#fragment")
+    )
   end
 
   it "should have the correct scheme after assignment" do
     @uri.scheme = "ftp"
-    @uri.scheme.should == "ftp"
-    @uri.to_s.should ==
+    expect(@uri.scheme).to eq("ftp")
+    expect(@uri.to_s).to eq(
       "ftp://user:pass@example.com/path/to/resource?query=x#fragment"
-    @uri.to_str.should ==
+    )
+    expect(@uri.to_str).to eq(
       "ftp://user:pass@example.com/path/to/resource?query=x#fragment"
+    )
     @uri.scheme = "bogus!"
-    @uri.scheme.should == "bogus!"
-    @uri.normalized_scheme.should == "bogus%21"
-    @uri.normalize.to_s.should ==
+    expect(@uri.scheme).to eq("bogus!")
+    expect(@uri.normalized_scheme).to eq("bogus%21")
+    expect(@uri.normalize.to_s).to eq(
       "bogus%21://user:pass@example.com/path/to/resource?query=x#fragment"
-    @uri.normalize.to_str.should ==
+    )
+    expect(@uri.normalize.to_str).to eq(
       "bogus%21://user:pass@example.com/path/to/resource?query=x#fragment"
+    )
   end
 
   it "should have the correct site segment after assignment" do
     @uri.site = "https://newuser:newpass@example.com:443"
-    @uri.scheme.should == "https"
-    @uri.authority.should == "newuser:newpass@example.com:443"
-    @uri.user.should == "newuser"
-    @uri.password.should == "newpass"
-    @uri.userinfo.should == "newuser:newpass"
-    @uri.normalized_userinfo.should == "newuser:newpass"
-    @uri.host.should == "example.com"
-    @uri.port.should == 443
-    @uri.inferred_port.should == 443
-    @uri.to_s.should ==
+    expect(@uri.scheme).to eq("https")
+    expect(@uri.authority).to eq("newuser:newpass@example.com:443")
+    expect(@uri.user).to eq("newuser")
+    expect(@uri.password).to eq("newpass")
+    expect(@uri.userinfo).to eq("newuser:newpass")
+    expect(@uri.normalized_userinfo).to eq("newuser:newpass")
+    expect(@uri.host).to eq("example.com")
+    expect(@uri.port).to eq(443)
+    expect(@uri.inferred_port).to eq(443)
+    expect(@uri.to_s).to eq(
       "https://newuser:newpass@example.com:443" +
       "/path/to/resource?query=x#fragment"
+    )
   end
 
   it "should have the correct authority segment after assignment" do
     @uri.authority = "newuser:newpass@example.com:80"
-    @uri.authority.should == "newuser:newpass@example.com:80"
-    @uri.user.should == "newuser"
-    @uri.password.should == "newpass"
-    @uri.userinfo.should == "newuser:newpass"
-    @uri.normalized_userinfo.should == "newuser:newpass"
-    @uri.host.should == "example.com"
-    @uri.port.should == 80
-    @uri.inferred_port.should == 80
-    @uri.to_s.should ==
+    expect(@uri.authority).to eq("newuser:newpass@example.com:80")
+    expect(@uri.user).to eq("newuser")
+    expect(@uri.password).to eq("newpass")
+    expect(@uri.userinfo).to eq("newuser:newpass")
+    expect(@uri.normalized_userinfo).to eq("newuser:newpass")
+    expect(@uri.host).to eq("example.com")
+    expect(@uri.port).to eq(80)
+    expect(@uri.inferred_port).to eq(80)
+    expect(@uri.to_s).to eq(
       "http://newuser:newpass@example.com:80" +
       "/path/to/resource?query=x#fragment"
+    )
   end
 
   it "should have the correct userinfo segment after assignment" do
     @uri.userinfo = "newuser:newpass"
-    @uri.userinfo.should == "newuser:newpass"
-    @uri.authority.should == "newuser:newpass@example.com"
-    @uri.user.should == "newuser"
-    @uri.password.should == "newpass"
-    @uri.host.should == "example.com"
-    @uri.port.should == nil
-    @uri.inferred_port.should == 80
-    @uri.to_s.should ==
+    expect(@uri.userinfo).to eq("newuser:newpass")
+    expect(@uri.authority).to eq("newuser:newpass@example.com")
+    expect(@uri.user).to eq("newuser")
+    expect(@uri.password).to eq("newpass")
+    expect(@uri.host).to eq("example.com")
+    expect(@uri.port).to eq(nil)
+    expect(@uri.inferred_port).to eq(80)
+    expect(@uri.to_s).to eq(
       "http://newuser:newpass@example.com" +
       "/path/to/resource?query=x#fragment"
+    )
   end
 
   it "should have the correct username after assignment" do
     @uri.user = "newuser"
-    @uri.user.should == "newuser"
-    @uri.authority.should == "newuser:pass@example.com"
+    expect(@uri.user).to eq("newuser")
+    expect(@uri.authority).to eq("newuser:pass@example.com")
   end
 
   it "should have the correct password after assignment" do
     @uri.password = "newpass"
-    @uri.password.should == "newpass"
-    @uri.authority.should == "user:newpass@example.com"
+    expect(@uri.password).to eq("newpass")
+    expect(@uri.authority).to eq("user:newpass@example.com")
   end
 
   it "should have the correct host after assignment" do
     @uri.host = "newexample.com"
-    @uri.host.should == "newexample.com"
-    @uri.authority.should == "user:pass@newexample.com"
+    expect(@uri.host).to eq("newexample.com")
+    expect(@uri.authority).to eq("user:pass@newexample.com")
   end
 
   it "should have the correct port after assignment" do
     @uri.port = 8080
-    @uri.port.should == 8080
-    @uri.authority.should == "user:pass@example.com:8080"
+    expect(@uri.port).to eq(8080)
+    expect(@uri.authority).to eq("user:pass@example.com:8080")
   end
 
   it "should have the correct path after assignment" do
     @uri.path = "/newpath/to/resource"
-    @uri.path.should == "/newpath/to/resource"
-    @uri.to_s.should ==
+    expect(@uri.path).to eq("/newpath/to/resource")
+    expect(@uri.to_s).to eq(
       "http://user:pass@example.com/newpath/to/resource?query=x#fragment"
+    )
   end
 
   it "should have the correct scheme and authority after nil assignment" do
     @uri.site = nil
-    @uri.scheme.should == nil
-    @uri.authority.should == nil
-    @uri.to_s.should == "/path/to/resource?query=x#fragment"
+    expect(@uri.scheme).to eq(nil)
+    expect(@uri.authority).to eq(nil)
+    expect(@uri.to_s).to eq("/path/to/resource?query=x#fragment")
   end
 
   it "should have the correct scheme and authority after assignment" do
     @uri.site = "file://"
-    @uri.scheme.should == "file"
-    @uri.authority.should == ""
-    @uri.to_s.should == "file:///path/to/resource?query=x#fragment"
+    expect(@uri.scheme).to eq("file")
+    expect(@uri.authority).to eq("")
+    expect(@uri.to_s).to eq("file:///path/to/resource?query=x#fragment")
   end
 
   it "should have the correct path after nil assignment" do
     @uri.path = nil
-    @uri.path.should == ""
-    @uri.to_s.should ==
+    expect(@uri.path).to eq("")
+    expect(@uri.to_s).to eq(
       "http://user:pass@example.com?query=x#fragment"
+    )
   end
 
   it "should have the correct query string after assignment" do
     @uri.query = "newquery=x"
-    @uri.query.should == "newquery=x"
-    @uri.to_s.should ==
+    expect(@uri.query).to eq("newquery=x")
+    expect(@uri.to_s).to eq(
       "http://user:pass@example.com/path/to/resource?newquery=x#fragment"
+    )
     @uri.query = nil
-    @uri.query.should == nil
-    @uri.to_s.should ==
+    expect(@uri.query).to eq(nil)
+    expect(@uri.to_s).to eq(
       "http://user:pass@example.com/path/to/resource#fragment"
+    )
   end
 
   it "should have the correct query string after hash assignment" do
     @uri.query_values = {"?uestion mark" => "=sign", "hello" => "g\xC3\xBCnther"}
-    @uri.query.split("&").should include("%3Fuestion%20mark=%3Dsign")
-    @uri.query.split("&").should include("hello=g%C3%BCnther")
-    @uri.query_values.should == {
+    expect(@uri.query.split("&")).to include("%3Fuestion%20mark=%3Dsign")
+    expect(@uri.query.split("&")).to include("hello=g%C3%BCnther")
+    expect(@uri.query_values).to eq({
       "?uestion mark" => "=sign", "hello" => "g\xC3\xBCnther"
-    }
+    })
   end
 
   it "should have the correct query string after flag hash assignment" do
     @uri.query_values = {'flag?1' => nil, 'fl=ag2' => nil, 'flag3' => nil}
-    @uri.query.split("&").should include("flag%3F1")
-    @uri.query.split("&").should include("fl%3Dag2")
-    @uri.query.split("&").should include("flag3")
-    @uri.query_values(Array).sort.should == [["fl=ag2"], ["flag3"], ["flag?1"]]
-    @uri.query_values(Hash).should == {
+    expect(@uri.query.split("&")).to include("flag%3F1")
+    expect(@uri.query.split("&")).to include("fl%3Dag2")
+    expect(@uri.query.split("&")).to include("flag3")
+    expect(@uri.query_values(Array).sort).to eq([["fl=ag2"], ["flag3"], ["flag?1"]])
+    expect(@uri.query_values(Hash)).to eq({
       'flag?1' => nil, 'fl=ag2' => nil, 'flag3' => nil
-    }
+    })
   end
 
   it "should raise an error if query values are set to a bogus type" do
-    (lambda do
+    expect(lambda do
       @uri.query_values = "bogus"
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "should have the correct fragment after assignment" do
     @uri.fragment = "newfragment"
-    @uri.fragment.should == "newfragment"
-    @uri.to_s.should ==
+    expect(@uri.fragment).to eq("newfragment")
+    expect(@uri.to_s).to eq(
       "http://user:pass@example.com/path/to/resource?query=x#newfragment"
+    )
 
     @uri.fragment = nil
-    @uri.fragment.should == nil
-    @uri.to_s.should ==
+    expect(@uri.fragment).to eq(nil)
+    expect(@uri.to_s).to eq(
       "http://user:pass@example.com/path/to/resource?query=x"
+    )
   end
 
   it "should have the correct values after a merge" do
-    @uri.merge(:fragment => "newfragment").to_s.should ==
+    expect(@uri.merge(:fragment => "newfragment").to_s).to eq(
       "http://user:pass@example.com/path/to/resource?query=x#newfragment"
+    )
   end
 
   it "should have the correct values after a merge" do
-    @uri.merge(:fragment => nil).to_s.should ==
+    expect(@uri.merge(:fragment => nil).to_s).to eq(
       "http://user:pass@example.com/path/to/resource?query=x"
+    )
   end
 
   it "should have the correct values after a merge" do
-    @uri.merge(:userinfo => "newuser:newpass").to_s.should ==
+    expect(@uri.merge(:userinfo => "newuser:newpass").to_s).to eq(
       "http://newuser:newpass@example.com/path/to/resource?query=x#fragment"
+    )
   end
 
   it "should have the correct values after a merge" do
-    @uri.merge(:userinfo => nil).to_s.should ==
+    expect(@uri.merge(:userinfo => nil).to_s).to eq(
       "http://example.com/path/to/resource?query=x#fragment"
+    )
   end
 
   it "should have the correct values after a merge" do
-    @uri.merge(:path => "newpath").to_s.should ==
+    expect(@uri.merge(:path => "newpath").to_s).to eq(
       "http://user:pass@example.com/newpath?query=x#fragment"
+    )
   end
 
   it "should have the correct values after a merge" do
-    @uri.merge(:port => "42", :path => "newpath", :query => "").to_s.should ==
+    expect(@uri.merge(:port => "42", :path => "newpath", :query => "").to_s).to eq(
       "http://user:pass@example.com:42/newpath?#fragment"
+    )
   end
 
   it "should have the correct values after a merge" do
-    @uri.merge(:authority => "foo:bar@baz:42").to_s.should ==
+    expect(@uri.merge(:authority => "foo:bar@baz:42").to_s).to eq(
       "http://foo:bar@baz:42/path/to/resource?query=x#fragment"
+    )
     # Ensure the operation was not destructive
-    @uri.to_s.should ==
+    expect(@uri.to_s).to eq(
       "http://user:pass@example.com/path/to/resource?query=x#fragment"
+    )
   end
 
   it "should have the correct values after a destructive merge" do
     @uri.merge!(:authority => "foo:bar@baz:42")
     # Ensure the operation was destructive
-    @uri.to_s.should ==
+    expect(@uri.to_s).to eq(
       "http://foo:bar@baz:42/path/to/resource?query=x#fragment"
+    )
   end
 
   it "should fail to merge with bogus values" do
-    (lambda do
+    expect(lambda do
       @uri.merge(:port => "bogus")
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 
   it "should fail to merge with bogus values" do
-    (lambda do
+    expect(lambda do
       @uri.merge(:authority => "bar@baz:bogus")
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 
   it "should fail to merge with bogus parameters" do
-    (lambda do
+    expect(lambda do
       @uri.merge(42)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "should fail to merge with bogus parameters" do
-    (lambda do
+    expect(lambda do
       @uri.merge("http://example.com/")
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "should fail to merge with both authority and subcomponents" do
-    (lambda do
+    expect(lambda do
       @uri.merge(:authority => "foo:bar@baz:42", :port => "42")
-    end).should raise_error(ArgumentError)
+    end).to raise_error(ArgumentError)
   end
 
   it "should fail to merge with both userinfo and subcomponents" do
-    (lambda do
+    expect(lambda do
       @uri.merge(:userinfo => "foo:bar", :user => "foo")
-    end).should raise_error(ArgumentError)
+    end).to raise_error(ArgumentError)
   end
 
   it "should be identical to its duplicate" do
-    @uri.should == @uri.dup
+    expect(@uri).to eq(@uri.dup)
   end
 
   it "should have an origin of 'http://example.com'" do
-    @uri.origin.should == 'http://example.com'
+    expect(@uri.origin).to eq('http://example.com')
   end
 end
 
@@ -3771,16 +3837,16 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a query of 'q=Q%26A'" do
-    @uri.query.should == "q=Q%26A"
+    expect(@uri.query).to eq("q=Q%26A")
   end
 
   it "should have query_values of {'q' => 'Q&A'}" do
-    @uri.query_values.should == { 'q' => 'Q&A' }
+    expect(@uri.query_values).to eq({ 'q' => 'Q&A' })
   end
 
   it "should normalize to the original uri " +
       "(with the ampersand properly percent-encoded)" do
-    @uri.normalize.to_s.should == "http://example.com/search?q=Q%26A"
+    expect(@uri.normalize.to_s).to eq("http://example.com/search?q=Q%26A")
   end
 end
 
@@ -3791,11 +3857,11 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a query of '&x=b'" do
-    @uri.query.should == "&x=b"
+    expect(@uri.query).to eq("&x=b")
   end
 
   it "should have query_values of {'x' => 'b'}" do
-    @uri.query_values.should == {'x' => 'b'}
+    expect(@uri.query_values).to eq({'x' => 'b'})
   end
 end
 
@@ -3806,17 +3872,17 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a query of 'q='one;two'&x=1'" do
-    @uri.query.should == "q='one;two'&x=1"
+    expect(@uri.query).to eq("q='one;two'&x=1")
   end
 
   it "should have query_values of {\"q\" => \"'one;two'\", \"x\" => \"1\"}" do
-    @uri.query_values.should == {"q" => "'one;two'", "x" => "1"}
+    expect(@uri.query_values).to eq({"q" => "'one;two'", "x" => "1"})
   end
 
   it "should escape the ';' character when normalizing to avoid ambiguity " +
       "with the W3C HTML 4.01 specification" do
     # HTML 4.01 Section B.2.2
-    @uri.normalize.query.should == "q='one%3Btwo'&x=1"
+    expect(@uri.normalize.query).to eq("q='one%3Btwo'&x=1")
   end
 end
 
@@ -3827,11 +3893,11 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a query of '&&x=b'" do
-    @uri.query.should == "&&x=b"
+    expect(@uri.query).to eq("&&x=b")
   end
 
   it "should have query_values of {'x' => 'b'}" do
-    @uri.query_values.should == {'x' => 'b'}
+    expect(@uri.query_values).to eq({'x' => 'b'})
   end
 end
 
@@ -3842,11 +3908,11 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a query of 'q=a&&x=b'" do
-    @uri.query.should == "q=a&&x=b"
+    expect(@uri.query).to eq("q=a&&x=b")
   end
 
   it "should have query_values of {'q' => 'a, 'x' => 'b'}" do
-    @uri.query_values.should == {'q' => 'a', 'x' => 'b'}
+    expect(@uri.query_values).to eq({'q' => 'a', 'x' => 'b'})
   end
 end
 
@@ -3857,11 +3923,11 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a query of 'q&&x=b'" do
-    @uri.query.should == "q&&x=b"
+    expect(@uri.query).to eq("q&&x=b")
   end
 
   it "should have query_values of {'q' => true, 'x' => 'b'}" do
-    @uri.query_values.should == {'q' => nil, 'x' => 'b'}
+    expect(@uri.query_values).to eq({'q' => nil, 'x' => 'b'})
   end
 end
 
@@ -3872,15 +3938,15 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a query of 'q=a+b'" do
-    @uri.query.should == "q=a+b"
+    expect(@uri.query).to eq("q=a+b")
   end
 
   it "should have query_values of {'q' => 'a b'}" do
-    @uri.query_values.should == {'q' => 'a b'}
+    expect(@uri.query_values).to eq({'q' => 'a b'})
   end
 
   it "should have a normalized query of 'q=a+b'" do
-    @uri.normalized_query.should == "q=a+b"
+    expect(@uri.normalized_query).to eq("q=a+b")
   end
 end
 
@@ -3891,15 +3957,15 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a query of 'q=a+b'" do
-    @uri.query.should == "q=a%2bb"
+    expect(@uri.query).to eq("q=a%2bb")
   end
 
   it "should have query_values of {'q' => 'a+b'}" do
-    @uri.query_values.should == {'q' => 'a+b'}
+    expect(@uri.query_values).to eq({'q' => 'a+b'})
   end
 
   it "should have a normalized query of 'q=a%2Bb'" do
-    @uri.normalized_query.should == "q=a%2Bb"
+    expect(@uri.normalized_query).to eq("q=a%2Bb")
   end
 end
 
@@ -3910,7 +3976,7 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a normalized query of 'v=~&w=%25&x=%25&y=%2B&z=%C3%87'" do
-    @uri.normalized_query.should == "v=~&w=%25&x=%25&y=%2B&z=%C3%87"
+    expect(@uri.normalized_query).to eq("v=~&w=%25&x=%25&y=%2B&z=%C3%87")
   end
 end
 
@@ -3921,7 +3987,7 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a normalized query of 'v=~&w=%25&x=%25&y=+&z=%C3%87'" do
-    @uri.normalized_query.should == "v=~&w=%25&x=%25&y=+&z=%C3%87"
+    expect(@uri.normalized_query).to eq("v=~&w=%25&x=%25&y=+&z=%C3%87")
   end
 end
 
@@ -3932,7 +3998,7 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a normalized path of '/sound+vision'" do
-    @uri.normalized_path.should == '/sound+vision'
+    expect(@uri.normalized_path).to eq('/sound+vision')
   end
 end
 
@@ -3943,11 +4009,11 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a query of 'q='" do
-    @uri.query.should == "q="
+    expect(@uri.query).to eq("q=")
   end
 
   it "should have query_values of {'q' => ''}" do
-    @uri.query_values.should == {'q' => ''}
+    expect(@uri.query_values).to eq({'q' => ''})
   end
 end
 
@@ -3958,88 +4024,88 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'http' scheme" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "should have a username of 'user'" do
-    @uri.user.should == "user"
+    expect(@uri.user).to eq("user")
   end
 
   it "should have no password" do
-    @uri.password.should == nil
+    expect(@uri.password).to eq(nil)
   end
 
   it "should have a userinfo of 'user'" do
-    @uri.userinfo.should == "user"
+    expect(@uri.userinfo).to eq("user")
   end
 
   it "should have a normalized userinfo of 'user'" do
-    @uri.normalized_userinfo.should == "user"
+    expect(@uri.normalized_userinfo).to eq("user")
   end
 
   it "should have a host of 'example.com'" do
-    @uri.host.should == "example.com"
+    expect(@uri.host).to eq("example.com")
   end
 
   it "should have default_port 80" do
-    @uri.default_port.should == 80
+    expect(@uri.default_port).to eq(80)
   end
 
   it "should use port 80" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should have the correct username after assignment" do
     @uri.user = "newuser"
-    @uri.user.should == "newuser"
-    @uri.password.should == nil
-    @uri.to_s.should == "http://newuser@example.com"
+    expect(@uri.user).to eq("newuser")
+    expect(@uri.password).to eq(nil)
+    expect(@uri.to_s).to eq("http://newuser@example.com")
   end
 
   it "should have the correct password after assignment" do
     @uri.password = "newpass"
-    @uri.password.should == "newpass"
-    @uri.to_s.should == "http://user:newpass@example.com"
+    expect(@uri.password).to eq("newpass")
+    expect(@uri.to_s).to eq("http://user:newpass@example.com")
   end
 
   it "should have the correct userinfo segment after assignment" do
     @uri.userinfo = "newuser:newpass"
-    @uri.userinfo.should == "newuser:newpass"
-    @uri.user.should == "newuser"
-    @uri.password.should == "newpass"
-    @uri.host.should == "example.com"
-    @uri.port.should == nil
-    @uri.inferred_port.should == 80
-    @uri.to_s.should == "http://newuser:newpass@example.com"
+    expect(@uri.userinfo).to eq("newuser:newpass")
+    expect(@uri.user).to eq("newuser")
+    expect(@uri.password).to eq("newpass")
+    expect(@uri.host).to eq("example.com")
+    expect(@uri.port).to eq(nil)
+    expect(@uri.inferred_port).to eq(80)
+    expect(@uri.to_s).to eq("http://newuser:newpass@example.com")
   end
 
   it "should have the correct userinfo segment after nil assignment" do
     @uri.userinfo = nil
-    @uri.userinfo.should == nil
-    @uri.user.should == nil
-    @uri.password.should == nil
-    @uri.host.should == "example.com"
-    @uri.port.should == nil
-    @uri.inferred_port.should == 80
-    @uri.to_s.should == "http://example.com"
+    expect(@uri.userinfo).to eq(nil)
+    expect(@uri.user).to eq(nil)
+    expect(@uri.password).to eq(nil)
+    expect(@uri.host).to eq("example.com")
+    expect(@uri.port).to eq(nil)
+    expect(@uri.inferred_port).to eq(80)
+    expect(@uri.to_s).to eq("http://example.com")
   end
 
   it "should have the correct authority segment after assignment" do
     @uri.authority = "newuser@example.com"
-    @uri.authority.should == "newuser@example.com"
-    @uri.user.should == "newuser"
-    @uri.password.should == nil
-    @uri.host.should == "example.com"
-    @uri.port.should == nil
-    @uri.inferred_port.should == 80
-    @uri.to_s.should == "http://newuser@example.com"
+    expect(@uri.authority).to eq("newuser@example.com")
+    expect(@uri.user).to eq("newuser")
+    expect(@uri.password).to eq(nil)
+    expect(@uri.host).to eq("example.com")
+    expect(@uri.port).to eq(nil)
+    expect(@uri.inferred_port).to eq(80)
+    expect(@uri.to_s).to eq("http://newuser@example.com")
   end
 
   it "should raise an error after nil assignment of authority segment" do
-    (lambda do
+    expect(lambda do
       # This would create an invalid URI
       @uri.authority = nil
-    end).should raise_error
+    end).to raise_error
   end
 end
 
@@ -4050,51 +4116,51 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'http' scheme" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "should have a username of 'user'" do
-    @uri.user.should == "user"
+    expect(@uri.user).to eq("user")
   end
 
   it "should have a password of ''" do
-    @uri.password.should == ""
+    expect(@uri.password).to eq("")
   end
 
   it "should have a normalized userinfo of 'user:'" do
-    @uri.normalized_userinfo.should == "user:"
+    expect(@uri.normalized_userinfo).to eq("user:")
   end
 
   it "should have a host of 'example.com'" do
-    @uri.host.should == "example.com"
+    expect(@uri.host).to eq("example.com")
   end
 
   it "should use port 80" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should have the correct username after assignment" do
     @uri.user = "newuser"
-    @uri.user.should == "newuser"
-    @uri.password.should == ""
-    @uri.to_s.should == "http://newuser:@example.com"
+    expect(@uri.user).to eq("newuser")
+    expect(@uri.password).to eq("")
+    expect(@uri.to_s).to eq("http://newuser:@example.com")
   end
 
   it "should have the correct password after assignment" do
     @uri.password = "newpass"
-    @uri.password.should == "newpass"
-    @uri.to_s.should == "http://user:newpass@example.com"
+    expect(@uri.password).to eq("newpass")
+    expect(@uri.to_s).to eq("http://user:newpass@example.com")
   end
 
   it "should have the correct authority segment after assignment" do
     @uri.authority = "newuser:@example.com"
-    @uri.authority.should == "newuser:@example.com"
-    @uri.user.should == "newuser"
-    @uri.password.should == ""
-    @uri.host.should == "example.com"
-    @uri.port.should == nil
-    @uri.inferred_port.should == 80
-    @uri.to_s.should == "http://newuser:@example.com"
+    expect(@uri.authority).to eq("newuser:@example.com")
+    expect(@uri.user).to eq("newuser")
+    expect(@uri.password).to eq("")
+    expect(@uri.host).to eq("example.com")
+    expect(@uri.port).to eq(nil)
+    expect(@uri.inferred_port).to eq(80)
+    expect(@uri.to_s).to eq("http://newuser:@example.com")
   end
 end
 
@@ -4105,56 +4171,56 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'http' scheme" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "should have a username of ''" do
-    @uri.user.should == ""
+    expect(@uri.user).to eq("")
   end
 
   it "should have a password of 'pass'" do
-    @uri.password.should == "pass"
+    expect(@uri.password).to eq("pass")
   end
 
   it "should have a userinfo of ':pass'" do
-    @uri.userinfo.should == ":pass"
+    expect(@uri.userinfo).to eq(":pass")
   end
 
   it "should have a normalized userinfo of ':pass'" do
-    @uri.normalized_userinfo.should == ":pass"
+    expect(@uri.normalized_userinfo).to eq(":pass")
   end
 
   it "should have a host of 'example.com'" do
-    @uri.host.should == "example.com"
+    expect(@uri.host).to eq("example.com")
   end
 
   it "should use port 80" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should have the correct username after assignment" do
     @uri.user = "newuser"
-    @uri.user.should == "newuser"
-    @uri.password.should == "pass"
-    @uri.to_s.should == "http://newuser:pass@example.com"
+    expect(@uri.user).to eq("newuser")
+    expect(@uri.password).to eq("pass")
+    expect(@uri.to_s).to eq("http://newuser:pass@example.com")
   end
 
   it "should have the correct password after assignment" do
     @uri.password = "newpass"
-    @uri.password.should == "newpass"
-    @uri.user.should == ""
-    @uri.to_s.should == "http://:newpass@example.com"
+    expect(@uri.password).to eq("newpass")
+    expect(@uri.user).to eq("")
+    expect(@uri.to_s).to eq("http://:newpass@example.com")
   end
 
   it "should have the correct authority segment after assignment" do
     @uri.authority = ":newpass@example.com"
-    @uri.authority.should == ":newpass@example.com"
-    @uri.user.should == ""
-    @uri.password.should == "newpass"
-    @uri.host.should == "example.com"
-    @uri.port.should == nil
-    @uri.inferred_port.should == 80
-    @uri.to_s.should == "http://:newpass@example.com"
+    expect(@uri.authority).to eq(":newpass@example.com")
+    expect(@uri.user).to eq("")
+    expect(@uri.password).to eq("newpass")
+    expect(@uri.host).to eq("example.com")
+    expect(@uri.port).to eq(nil)
+    expect(@uri.inferred_port).to eq(80)
+    expect(@uri.to_s).to eq("http://:newpass@example.com")
   end
 end
 
@@ -4165,52 +4231,52 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'http' scheme" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "should have a username of ''" do
-    @uri.user.should == ""
+    expect(@uri.user).to eq("")
   end
 
   it "should have a password of ''" do
-    @uri.password.should == ""
+    expect(@uri.password).to eq("")
   end
 
   it "should have a normalized userinfo of nil" do
-    @uri.normalized_userinfo.should == nil
+    expect(@uri.normalized_userinfo).to eq(nil)
   end
 
   it "should have a host of 'example.com'" do
-    @uri.host.should == "example.com"
+    expect(@uri.host).to eq("example.com")
   end
 
   it "should use port 80" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should have the correct username after assignment" do
     @uri.user = "newuser"
-    @uri.user.should == "newuser"
-    @uri.password.should == ""
-    @uri.to_s.should == "http://newuser:@example.com"
+    expect(@uri.user).to eq("newuser")
+    expect(@uri.password).to eq("")
+    expect(@uri.to_s).to eq("http://newuser:@example.com")
   end
 
   it "should have the correct password after assignment" do
     @uri.password = "newpass"
-    @uri.password.should == "newpass"
-    @uri.user.should == ""
-    @uri.to_s.should == "http://:newpass@example.com"
+    expect(@uri.password).to eq("newpass")
+    expect(@uri.user).to eq("")
+    expect(@uri.to_s).to eq("http://:newpass@example.com")
   end
 
   it "should have the correct authority segment after assignment" do
     @uri.authority = ":@newexample.com"
-    @uri.authority.should == ":@newexample.com"
-    @uri.user.should == ""
-    @uri.password.should == ""
-    @uri.host.should == "newexample.com"
-    @uri.port.should == nil
-    @uri.inferred_port.should == 80
-    @uri.to_s.should == "http://:@newexample.com"
+    expect(@uri.authority).to eq(":@newexample.com")
+    expect(@uri.user).to eq("")
+    expect(@uri.password).to eq("")
+    expect(@uri.host).to eq("newexample.com")
+    expect(@uri.port).to eq(nil)
+    expect(@uri.inferred_port).to eq(80)
+    expect(@uri.to_s).to eq("http://:@newexample.com")
   end
 end
 
@@ -4221,31 +4287,31 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should be considered relative" do
-    @uri.should be_relative
+    expect(@uri).to be_relative
   end
 
   it "should have a host of nil" do
-    @uri.host.should == nil
+    expect(@uri.host).to eq(nil)
   end
 
   it "should have a site of nil" do
-    @uri.site.should == nil
+    expect(@uri.site).to eq(nil)
   end
 
   it "should have a normalized_site of nil" do
-    @uri.normalized_site.should == nil
+    expect(@uri.normalized_site).to eq(nil)
   end
 
   it "should have a path of ''" do
-    @uri.path.should == ""
+    expect(@uri.path).to eq("")
   end
 
   it "should have a query string of nil" do
-    @uri.query.should == nil
+    expect(@uri.query).to eq(nil)
   end
 
   it "should have a fragment of 'example'" do
-    @uri.fragment.should == "example"
+    expect(@uri.fragment).to eq("example")
   end
 end
 
@@ -4256,28 +4322,28 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should be considered relative" do
-    @uri.should be_relative
+    expect(@uri).to be_relative
   end
 
   it "should have a host of 'example.com'" do
-    @uri.host.should == "example.com"
+    expect(@uri.host).to eq("example.com")
   end
 
   it "should have a path of '/'" do
-    @uri.path.should == "/"
+    expect(@uri.path).to eq("/")
   end
 
   it "should raise an error if routing is attempted" do
-    (lambda do
+    expect(lambda do
       @uri.route_to("http://example.com/")
-    end).should raise_error(ArgumentError, /\/\/example.com\//)
-    (lambda do
+    end).to raise_error(ArgumentError, /\/\/example.com\//)
+    expect(lambda do
       @uri.route_from("http://example.com/")
-    end).should raise_error(ArgumentError, /\/\/example.com\//)
+    end).to raise_error(ArgumentError, /\/\/example.com\//)
   end
 
   it "should have a 'null' origin" do
-    @uri.origin.should == 'null'
+    expect(@uri.origin).to eq('null')
   end
 end
 
@@ -4288,11 +4354,11 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a host of 'http'" do
-    @uri.host.should == "http"
+    expect(@uri.host).to eq("http")
   end
 
   it "should have a path of '//example.com/'" do
-    @uri.path.should == "//example.com/"
+    expect(@uri.path).to eq("//example.com/")
   end
 end
 
@@ -4303,16 +4369,16 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have a path of 'http://example.com/'" do
-    @uri.path.should == "http://example.com/"
+    expect(@uri.path).to eq("http://example.com/")
   end
 
   it "should normalize to 'http://example.com/'" do
-    @uri.normalize.to_s.should == "http://example.com/"
-    @uri.normalize!.to_s.should == "http://example.com/"
+    expect(@uri.normalize.to_s).to eq("http://example.com/")
+    expect(@uri.normalize!.to_s).to eq("http://example.com/")
   end
 
   it "should have a 'null' origin" do
-    @uri.origin.should == 'null'
+    expect(@uri.origin).to eq('null')
   end
 end
 
@@ -4324,12 +4390,13 @@ describe Addressable::URI, "when parsed from " +
 
   # Section 6.2.2 of RFC 3986
   it "should be equivalent to eXAMPLE://a/./b/../b/%63/%7bfoo%7d" do
-    @uri.should ==
+    expect(@uri).to eq(
       Addressable::URI.parse("eXAMPLE://a/./b/../b/%63/%7bfoo%7d")
+    )
   end
 
   it "should have an origin of 'example://a'" do
-    @uri.origin.should == 'example://a'
+    expect(@uri.origin).to eq('example://a')
   end
 end
 
@@ -4341,34 +4408,34 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should use the 'http' scheme" do
-    @uri.scheme.should == "http"
+    expect(@uri.scheme).to eq("http")
   end
 
   it "should have a host of 'example.com'" do
-    @uri.host.should == "example.com"
+    expect(@uri.host).to eq("example.com")
   end
 
   it "should use port 80" do
-    @uri.inferred_port.should == 80
+    expect(@uri.inferred_port).to eq(80)
   end
 
   it "should have a path of '/indirect/path/./to/../resource/'" do
-    @uri.path.should == "/indirect/path/./to/../resource/"
+    expect(@uri.path).to eq("/indirect/path/./to/../resource/")
   end
 
   # Section 6.2.2.3 of RFC 3986
   it "should have a normalized path of '/indirect/path/resource/'" do
-    @uri.normalize.path.should == "/indirect/path/resource/"
-    @uri.normalize!.path.should == "/indirect/path/resource/"
+    expect(@uri.normalize.path).to eq("/indirect/path/resource/")
+    expect(@uri.normalize!.path).to eq("/indirect/path/resource/")
   end
 end
 
 describe Addressable::URI, "when parsed from " +
     "'http://under_score.example.com/'" do
   it "should not cause an error" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.parse("http://under_score.example.com/")
-    end).should_not raise_error
+    end).not_to raise_error
   end
 end
 
@@ -4379,15 +4446,15 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should be considered relative" do
-    @uri.should be_relative
+    expect(@uri).to be_relative
   end
 
   it "should have no scheme" do
-    @uri.scheme.should == nil
+    expect(@uri.scheme).to eq(nil)
   end
 
   it "should have a 'null' origin" do
-    @uri.origin.should == 'null'
+    expect(@uri.origin).to eq('null')
   end
 end
 
@@ -4398,15 +4465,15 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should be considered absolute" do
-    @uri.should be_absolute
+    expect(@uri).to be_absolute
   end
 
   it "should have a scheme of 'this'" do
-    @uri.scheme.should == "this"
+    expect(@uri.scheme).to eq("this")
   end
 
   it "should have a 'null' origin" do
-    @uri.origin.should == 'null'
+    expect(@uri.origin).to eq('null')
   end
 end
 
@@ -4416,17 +4483,17 @@ describe Addressable::URI, "when parsed from '?'" do
   end
 
   it "should normalize to ''" do
-    @uri.normalize.to_s.should == ""
+    expect(@uri.normalize.to_s).to eq("")
   end
 
   it "should have the correct return type" do
-    @uri.query_values.should == {}
-    @uri.query_values(Hash).should == {}
-    @uri.query_values(Array).should == []
+    expect(@uri.query_values).to eq({})
+    expect(@uri.query_values(Hash)).to eq({})
+    expect(@uri.query_values(Array)).to eq([])
   end
 
   it "should have a 'null' origin" do
-    @uri.origin.should == 'null'
+    expect(@uri.origin).to eq('null')
   end
 end
 
@@ -4436,23 +4503,23 @@ describe Addressable::URI, "when parsed from '?one=1&two=2&three=3'" do
   end
 
   it "should have the correct query values" do
-    @uri.query_values.should == {"one" => "1", "two" => "2", "three" => "3"}
+    expect(@uri.query_values).to eq({"one" => "1", "two" => "2", "three" => "3"})
   end
 
   it "should raise an error for invalid return type values" do
-    (lambda do
+    expect(lambda do
       @uri.query_values(Fixnum)
-    end).should raise_error(ArgumentError)
+    end).to raise_error(ArgumentError)
   end
 
   it "should have the correct array query values" do
-    @uri.query_values(Array).should == [
+    expect(@uri.query_values(Array)).to eq([
       ["one", "1"], ["two", "2"], ["three", "3"]
-    ]
+    ])
   end
 
   it "should have a 'null' origin" do
-    @uri.origin.should == 'null'
+    expect(@uri.origin).to eq('null')
   end
 end
 
@@ -4462,13 +4529,13 @@ describe Addressable::URI, "when parsed from '?one=1=uno&two=2=dos'" do
   end
 
   it "should have the correct query values" do
-    @uri.query_values.should == {"one" => "1=uno", "two" => "2=dos"}
+    expect(@uri.query_values).to eq({"one" => "1=uno", "two" => "2=dos"})
   end
 
   it "should have the correct array query values" do
-    @uri.query_values(Array).should == [
+    expect(@uri.query_values(Array)).to eq([
       ["one", "1=uno"], ["two", "2=dos"]
-    ]
+    ])
   end
 end
 
@@ -4478,13 +4545,13 @@ describe Addressable::URI, "when parsed from '?one[two][three]=four'" do
   end
 
   it "should have the correct query values" do
-    @uri.query_values.should == {"one[two][three]" => "four"}
+    expect(@uri.query_values).to eq({"one[two][three]" => "four"})
   end
 
   it "should have the correct array query values" do
-    @uri.query_values(Array).should == [
+    expect(@uri.query_values(Array)).to eq([
       ["one[two][three]", "four"]
-    ]
+    ])
   end
 end
 
@@ -4494,15 +4561,15 @@ describe Addressable::URI, "when parsed from '?one.two.three=four'" do
   end
 
   it "should have the correct query values" do
-    @uri.query_values.should == {
+    expect(@uri.query_values).to eq({
       "one.two.three" => "four"
-    }
+    })
   end
 
   it "should have the correct array query values" do
-    @uri.query_values(Array).should == [
+    expect(@uri.query_values(Array)).to eq([
       ["one.two.three", "four"]
-    ]
+    ])
   end
 end
 
@@ -4513,15 +4580,15 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have the correct query values" do
-    @uri.query_values.should == {
+    expect(@uri.query_values).to eq({
       "one[two][three]" => "four", "one[two][five]" => "six"
-    }
+    })
   end
 
   it "should have the correct array query values" do
-    @uri.query_values(Array).should == [
+    expect(@uri.query_values(Array)).to eq([
       ["one[two][three]", "four"], ["one[two][five]", "six"]
-    ]
+    ])
   end
 end
 
@@ -4532,15 +4599,15 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have the correct query values" do
-    @uri.query_values.should == {
+    expect(@uri.query_values).to eq({
       "one.two.three" => "four", "one.two.five" => "six"
-    }
+    })
   end
 
   it "should have the correct array query values" do
-    @uri.query_values(Array).should == [
+    expect(@uri.query_values(Array)).to eq([
       ["one.two.three", "four"], ["one.two.five", "six"]
-    ]
+    ])
   end
 end
 
@@ -4553,20 +4620,21 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have correct array query values" do
-    @uri.query_values(Array).should ==
+    expect(@uri.query_values(Array)).to eq(
       [['one', 'two'], ['one', 'three'], ['one', 'four']]
+    )
   end
 
   it "should have correct hash query values" do
-    pending("This is probably more desirable behavior.") do
-      @uri.query_values(Hash).should ==
-        {'one' => ['two', 'three', 'four']}
-    end
+    skip("This is probably more desirable behavior.")
+    expect(@uri.query_values(Hash)).to eq(
+      {'one' => ['two', 'three', 'four']}
+      )
   end
 
   it "should handle assignment with keys of mixed type" do
     @uri.query_values = @uri.query_values(Hash).merge({:one => 'three'})
-    @uri.query_values(Hash).should == {'one' => 'three'}
+    expect(@uri.query_values(Hash)).to eq({'one' => 'three'})
   end
 end
 
@@ -4579,13 +4647,13 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have correct query values" do
-    @uri.query_values(Hash).should == {"one[two][three][]" => "five"}
+    expect(@uri.query_values(Hash)).to eq({"one[two][three][]" => "five"})
   end
 
   it "should have correct array query values" do
-    @uri.query_values(Array).should == [
+    expect(@uri.query_values(Array)).to eq([
       ["one[two][three][]", "four"], ["one[two][three][]", "five"]
-    ]
+    ])
   end
 end
 
@@ -4598,9 +4666,9 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have the correct query values" do
-    @uri.query_values.should == {
+    expect(@uri.query_values).to eq({
       "one[two][three][0]" => "four", "one[two][three][1]" => "five"
-    }
+    })
   end
 end
 
@@ -4613,9 +4681,9 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have the correct query values" do
-    @uri.query_values.should == {
+    expect(@uri.query_values).to eq({
       "one[two][three][1]" => "four", "one[two][three][0]" => "five"
-    }
+    })
   end
 end
 
@@ -4628,9 +4696,9 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have the correct query values" do
-    @uri.query_values.should == {
+    expect(@uri.query_values).to eq({
       "one[two][three][2]" => "four", "one[two][three][1]" => "five"
-    }
+    })
   end
 end
 
@@ -4641,17 +4709,19 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should be equivalent to 'http://www.xn--8ws00zhy3a.com/'" do
-    @uri.should ==
+    expect(@uri).to eq(
       Addressable::URI.parse("http://www.xn--8ws00zhy3a.com/")
+    )
   end
 
   it "should not have domain name encoded during normalization" do
-    Addressable::URI.normalized_encode(@uri.to_s).should ==
+    expect(Addressable::URI.normalized_encode(@uri.to_s)).to eq(
       "http://www.詹姆斯.com/"
+    )
   end
 
   it "should have an origin of 'http://www.xn--8ws00zhy3a.com'" do
-    @uri.origin.should == 'http://www.xn--8ws00zhy3a.com'
+    expect(@uri.origin).to eq('http://www.xn--8ws00zhy3a.com')
   end
 end
 
@@ -4663,18 +4733,20 @@ describe Addressable::URI, "when parsed from " +
 
   it "should be equivalent to " +
       "'http://www.xn--8ws00zhy3a.com/%20some%20spaces%20/'" do
-    @uri.should ==
+    expect(@uri).to eq(
       Addressable::URI.parse(
         "http://www.xn--8ws00zhy3a.com/%20some%20spaces%20/")
+    )
   end
 
   it "should not have domain name encoded during normalization" do
-    Addressable::URI.normalized_encode(@uri.to_s).should ==
+    expect(Addressable::URI.normalized_encode(@uri.to_s)).to eq(
       "http://www.詹姆斯.com/%20some%20spaces%20/"
+    )
   end
 
   it "should have an origin of 'http://www.xn--8ws00zhy3a.com'" do
-    @uri.origin.should == 'http://www.xn--8ws00zhy3a.com'
+    expect(@uri.origin).to eq('http://www.xn--8ws00zhy3a.com')
   end
 end
 
@@ -4685,19 +4757,19 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should be displayed as http://www.詹姆斯.com/" do
-    @uri.display_uri.to_s.should == "http://www.詹姆斯.com/"
+    expect(@uri.display_uri.to_s).to eq("http://www.詹姆斯.com/")
   end
 
   it "should properly force the encoding" do
     display_string = @uri.display_uri.to_str
-    display_string.should == "http://www.詹姆斯.com/"
+    expect(display_string).to eq("http://www.詹姆斯.com/")
     if display_string.respond_to?(:encoding)
-      display_string.encoding.to_s.should == Encoding::UTF_8.to_s
+      expect(display_string.encoding.to_s).to eq(Encoding::UTF_8.to_s)
     end
   end
 
   it "should have an origin of 'http://www.xn--8ws00zhy3a.com'" do
-    @uri.origin.should == 'http://www.xn--8ws00zhy3a.com'
+    expect(@uri.origin).to eq('http://www.xn--8ws00zhy3a.com')
   end
 end
 
@@ -4709,10 +4781,12 @@ describe Addressable::URI, "when parsed from " +
 
   it "should normalize to " +
       "http://www.xn--8ws00zhy3a.com/atomtests/iri/%E8%A9%B9.html" do
-    @uri.normalize.to_s.should ==
+    expect(@uri.normalize.to_s).to eq(
       "http://www.xn--8ws00zhy3a.com/atomtests/iri/%E8%A9%B9.html"
-    @uri.normalize!.to_s.should ==
+    )
+    expect(@uri.normalize!.to_s).to eq(
       "http://www.xn--8ws00zhy3a.com/atomtests/iri/%E8%A9%B9.html"
+    )
   end
 end
 
@@ -4729,16 +4803,18 @@ describe Addressable::URI, "when parsed from a percent-encoded IRI" do
   end
 
   it "should normalize to something sane" do
-    @uri.normalize.to_s.should ==
+    expect(@uri.normalize.to_s).to eq(
       "http://www.xn--n8jaaaaai5bhf7as8fsfk3jnknefdde3f" +
       "g11amb5gzdb4wi9bya3kc6lra.w3.mag.keio.ac.jp/"
-    @uri.normalize!.to_s.should ==
+    )
+    expect(@uri.normalize!.to_s).to eq(
       "http://www.xn--n8jaaaaai5bhf7as8fsfk3jnknefdde3f" +
       "g11amb5gzdb4wi9bya3kc6lra.w3.mag.keio.ac.jp/"
+    )
   end
 
   it "should have the correct origin" do
-    @uri.origin.should == (
+    expect(@uri.origin).to eq(
       "http://www.xn--n8jaaaaai5bhf7as8fsfk3jnknefdde3f" +
       "g11amb5gzdb4wi9bya3kc6lra.w3.mag.keio.ac.jp"
     )
@@ -4752,289 +4828,291 @@ describe Addressable::URI, "with a base uri of 'http://a/b/c/d;p?q'" do
 
   # Section 5.4.1 of RFC 3986
   it "when joined with 'g:h' should resolve to g:h" do
-    (@uri + "g:h").to_s.should == "g:h"
-    Addressable::URI.join(@uri, "g:h").to_s.should == "g:h"
+    expect((@uri + "g:h").to_s).to eq("g:h")
+    expect(Addressable::URI.join(@uri, "g:h").to_s).to eq("g:h")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with 'g' should resolve to http://a/b/c/g" do
-    (@uri + "g").to_s.should == "http://a/b/c/g"
-    Addressable::URI.join(@uri.to_s, "g").to_s.should == "http://a/b/c/g"
+    expect((@uri + "g").to_s).to eq("http://a/b/c/g")
+    expect(Addressable::URI.join(@uri.to_s, "g").to_s).to eq("http://a/b/c/g")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with './g' should resolve to http://a/b/c/g" do
-    (@uri + "./g").to_s.should == "http://a/b/c/g"
-    Addressable::URI.join(@uri.to_s, "./g").to_s.should == "http://a/b/c/g"
+    expect((@uri + "./g").to_s).to eq("http://a/b/c/g")
+    expect(Addressable::URI.join(@uri.to_s, "./g").to_s).to eq("http://a/b/c/g")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with 'g/' should resolve to http://a/b/c/g/" do
-    (@uri + "g/").to_s.should == "http://a/b/c/g/"
-    Addressable::URI.join(@uri.to_s, "g/").to_s.should == "http://a/b/c/g/"
+    expect((@uri + "g/").to_s).to eq("http://a/b/c/g/")
+    expect(Addressable::URI.join(@uri.to_s, "g/").to_s).to eq("http://a/b/c/g/")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with '/g' should resolve to http://a/g" do
-    (@uri + "/g").to_s.should == "http://a/g"
-    Addressable::URI.join(@uri.to_s, "/g").to_s.should == "http://a/g"
+    expect((@uri + "/g").to_s).to eq("http://a/g")
+    expect(Addressable::URI.join(@uri.to_s, "/g").to_s).to eq("http://a/g")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with '//g' should resolve to http://g" do
-    (@uri + "//g").to_s.should == "http://g"
-    Addressable::URI.join(@uri.to_s, "//g").to_s.should == "http://g"
+    expect((@uri + "//g").to_s).to eq("http://g")
+    expect(Addressable::URI.join(@uri.to_s, "//g").to_s).to eq("http://g")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with '?y' should resolve to http://a/b/c/d;p?y" do
-    (@uri + "?y").to_s.should == "http://a/b/c/d;p?y"
-    Addressable::URI.join(@uri.to_s, "?y").to_s.should == "http://a/b/c/d;p?y"
+    expect((@uri + "?y").to_s).to eq("http://a/b/c/d;p?y")
+    expect(Addressable::URI.join(@uri.to_s, "?y").to_s).to eq("http://a/b/c/d;p?y")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with 'g?y' should resolve to http://a/b/c/g?y" do
-    (@uri + "g?y").to_s.should == "http://a/b/c/g?y"
-    Addressable::URI.join(@uri.to_s, "g?y").to_s.should == "http://a/b/c/g?y"
+    expect((@uri + "g?y").to_s).to eq("http://a/b/c/g?y")
+    expect(Addressable::URI.join(@uri.to_s, "g?y").to_s).to eq("http://a/b/c/g?y")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with '#s' should resolve to http://a/b/c/d;p?q#s" do
-    (@uri + "#s").to_s.should == "http://a/b/c/d;p?q#s"
-    Addressable::URI.join(@uri.to_s, "#s").to_s.should ==
+    expect((@uri + "#s").to_s).to eq("http://a/b/c/d;p?q#s")
+    expect(Addressable::URI.join(@uri.to_s, "#s").to_s).to eq(
       "http://a/b/c/d;p?q#s"
+    )
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with 'g#s' should resolve to http://a/b/c/g#s" do
-    (@uri + "g#s").to_s.should == "http://a/b/c/g#s"
-    Addressable::URI.join(@uri.to_s, "g#s").to_s.should == "http://a/b/c/g#s"
+    expect((@uri + "g#s").to_s).to eq("http://a/b/c/g#s")
+    expect(Addressable::URI.join(@uri.to_s, "g#s").to_s).to eq("http://a/b/c/g#s")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with 'g?y#s' should resolve to http://a/b/c/g?y#s" do
-    (@uri + "g?y#s").to_s.should == "http://a/b/c/g?y#s"
-    Addressable::URI.join(
-      @uri.to_s, "g?y#s").to_s.should == "http://a/b/c/g?y#s"
+    expect((@uri + "g?y#s").to_s).to eq("http://a/b/c/g?y#s")
+    expect(Addressable::URI.join(
+      @uri.to_s, "g?y#s").to_s).to eq("http://a/b/c/g?y#s")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with ';x' should resolve to http://a/b/c/;x" do
-    (@uri + ";x").to_s.should == "http://a/b/c/;x"
-    Addressable::URI.join(@uri.to_s, ";x").to_s.should == "http://a/b/c/;x"
+    expect((@uri + ";x").to_s).to eq("http://a/b/c/;x")
+    expect(Addressable::URI.join(@uri.to_s, ";x").to_s).to eq("http://a/b/c/;x")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with 'g;x' should resolve to http://a/b/c/g;x" do
-    (@uri + "g;x").to_s.should == "http://a/b/c/g;x"
-    Addressable::URI.join(@uri.to_s, "g;x").to_s.should == "http://a/b/c/g;x"
+    expect((@uri + "g;x").to_s).to eq("http://a/b/c/g;x")
+    expect(Addressable::URI.join(@uri.to_s, "g;x").to_s).to eq("http://a/b/c/g;x")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with 'g;x?y#s' should resolve to http://a/b/c/g;x?y#s" do
-    (@uri + "g;x?y#s").to_s.should == "http://a/b/c/g;x?y#s"
-    Addressable::URI.join(
-      @uri.to_s, "g;x?y#s").to_s.should == "http://a/b/c/g;x?y#s"
+    expect((@uri + "g;x?y#s").to_s).to eq("http://a/b/c/g;x?y#s")
+    expect(Addressable::URI.join(
+      @uri.to_s, "g;x?y#s").to_s).to eq("http://a/b/c/g;x?y#s")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with '' should resolve to http://a/b/c/d;p?q" do
-    (@uri + "").to_s.should == "http://a/b/c/d;p?q"
-    Addressable::URI.join(@uri.to_s, "").to_s.should == "http://a/b/c/d;p?q"
+    expect((@uri + "").to_s).to eq("http://a/b/c/d;p?q")
+    expect(Addressable::URI.join(@uri.to_s, "").to_s).to eq("http://a/b/c/d;p?q")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with '.' should resolve to http://a/b/c/" do
-    (@uri + ".").to_s.should == "http://a/b/c/"
-    Addressable::URI.join(@uri.to_s, ".").to_s.should == "http://a/b/c/"
+    expect((@uri + ".").to_s).to eq("http://a/b/c/")
+    expect(Addressable::URI.join(@uri.to_s, ".").to_s).to eq("http://a/b/c/")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with './' should resolve to http://a/b/c/" do
-    (@uri + "./").to_s.should == "http://a/b/c/"
-    Addressable::URI.join(@uri.to_s, "./").to_s.should == "http://a/b/c/"
+    expect((@uri + "./").to_s).to eq("http://a/b/c/")
+    expect(Addressable::URI.join(@uri.to_s, "./").to_s).to eq("http://a/b/c/")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with '..' should resolve to http://a/b/" do
-    (@uri + "..").to_s.should == "http://a/b/"
-    Addressable::URI.join(@uri.to_s, "..").to_s.should == "http://a/b/"
+    expect((@uri + "..").to_s).to eq("http://a/b/")
+    expect(Addressable::URI.join(@uri.to_s, "..").to_s).to eq("http://a/b/")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with '../' should resolve to http://a/b/" do
-    (@uri + "../").to_s.should == "http://a/b/"
-    Addressable::URI.join(@uri.to_s, "../").to_s.should == "http://a/b/"
+    expect((@uri + "../").to_s).to eq("http://a/b/")
+    expect(Addressable::URI.join(@uri.to_s, "../").to_s).to eq("http://a/b/")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with '../g' should resolve to http://a/b/g" do
-    (@uri + "../g").to_s.should == "http://a/b/g"
-    Addressable::URI.join(@uri.to_s, "../g").to_s.should == "http://a/b/g"
+    expect((@uri + "../g").to_s).to eq("http://a/b/g")
+    expect(Addressable::URI.join(@uri.to_s, "../g").to_s).to eq("http://a/b/g")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with '../..' should resolve to http://a/" do
-    (@uri + "../..").to_s.should == "http://a/"
-    Addressable::URI.join(@uri.to_s, "../..").to_s.should == "http://a/"
+    expect((@uri + "../..").to_s).to eq("http://a/")
+    expect(Addressable::URI.join(@uri.to_s, "../..").to_s).to eq("http://a/")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with '../../' should resolve to http://a/" do
-    (@uri + "../../").to_s.should == "http://a/"
-    Addressable::URI.join(@uri.to_s, "../../").to_s.should == "http://a/"
+    expect((@uri + "../../").to_s).to eq("http://a/")
+    expect(Addressable::URI.join(@uri.to_s, "../../").to_s).to eq("http://a/")
   end
 
   # Section 5.4.1 of RFC 3986
   it "when joined with '../../g' should resolve to http://a/g" do
-    (@uri + "../../g").to_s.should == "http://a/g"
-    Addressable::URI.join(@uri.to_s, "../../g").to_s.should == "http://a/g"
+    expect((@uri + "../../g").to_s).to eq("http://a/g")
+    expect(Addressable::URI.join(@uri.to_s, "../../g").to_s).to eq("http://a/g")
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with '../../../g' should resolve to http://a/g" do
-    (@uri + "../../../g").to_s.should == "http://a/g"
-    Addressable::URI.join(@uri.to_s, "../../../g").to_s.should == "http://a/g"
+    expect((@uri + "../../../g").to_s).to eq("http://a/g")
+    expect(Addressable::URI.join(@uri.to_s, "../../../g").to_s).to eq("http://a/g")
   end
 
   it "when joined with '../.././../g' should resolve to http://a/g" do
-    (@uri + "../.././../g").to_s.should == "http://a/g"
-    Addressable::URI.join(@uri.to_s, "../.././../g").to_s.should ==
+    expect((@uri + "../.././../g").to_s).to eq("http://a/g")
+    expect(Addressable::URI.join(@uri.to_s, "../.././../g").to_s).to eq(
       "http://a/g"
+    )
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with '../../../../g' should resolve to http://a/g" do
-    (@uri + "../../../../g").to_s.should == "http://a/g"
-    Addressable::URI.join(
-      @uri.to_s, "../../../../g").to_s.should == "http://a/g"
+    expect((@uri + "../../../../g").to_s).to eq("http://a/g")
+    expect(Addressable::URI.join(
+      @uri.to_s, "../../../../g").to_s).to eq("http://a/g")
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with '/./g' should resolve to http://a/g" do
-    (@uri + "/./g").to_s.should == "http://a/g"
-    Addressable::URI.join(@uri.to_s, "/./g").to_s.should == "http://a/g"
+    expect((@uri + "/./g").to_s).to eq("http://a/g")
+    expect(Addressable::URI.join(@uri.to_s, "/./g").to_s).to eq("http://a/g")
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with '/../g' should resolve to http://a/g" do
-    (@uri + "/../g").to_s.should == "http://a/g"
-    Addressable::URI.join(@uri.to_s, "/../g").to_s.should == "http://a/g"
+    expect((@uri + "/../g").to_s).to eq("http://a/g")
+    expect(Addressable::URI.join(@uri.to_s, "/../g").to_s).to eq("http://a/g")
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with 'g.' should resolve to http://a/b/c/g." do
-    (@uri + "g.").to_s.should == "http://a/b/c/g."
-    Addressable::URI.join(@uri.to_s, "g.").to_s.should == "http://a/b/c/g."
+    expect((@uri + "g.").to_s).to eq("http://a/b/c/g.")
+    expect(Addressable::URI.join(@uri.to_s, "g.").to_s).to eq("http://a/b/c/g.")
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with '.g' should resolve to http://a/b/c/.g" do
-    (@uri + ".g").to_s.should == "http://a/b/c/.g"
-    Addressable::URI.join(@uri.to_s, ".g").to_s.should == "http://a/b/c/.g"
+    expect((@uri + ".g").to_s).to eq("http://a/b/c/.g")
+    expect(Addressable::URI.join(@uri.to_s, ".g").to_s).to eq("http://a/b/c/.g")
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with 'g..' should resolve to http://a/b/c/g.." do
-    (@uri + "g..").to_s.should == "http://a/b/c/g.."
-    Addressable::URI.join(@uri.to_s, "g..").to_s.should == "http://a/b/c/g.."
+    expect((@uri + "g..").to_s).to eq("http://a/b/c/g..")
+    expect(Addressable::URI.join(@uri.to_s, "g..").to_s).to eq("http://a/b/c/g..")
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with '..g' should resolve to http://a/b/c/..g" do
-    (@uri + "..g").to_s.should == "http://a/b/c/..g"
-    Addressable::URI.join(@uri.to_s, "..g").to_s.should == "http://a/b/c/..g"
+    expect((@uri + "..g").to_s).to eq("http://a/b/c/..g")
+    expect(Addressable::URI.join(@uri.to_s, "..g").to_s).to eq("http://a/b/c/..g")
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with './../g' should resolve to http://a/b/g" do
-    (@uri + "./../g").to_s.should == "http://a/b/g"
-    Addressable::URI.join(@uri.to_s, "./../g").to_s.should == "http://a/b/g"
+    expect((@uri + "./../g").to_s).to eq("http://a/b/g")
+    expect(Addressable::URI.join(@uri.to_s, "./../g").to_s).to eq("http://a/b/g")
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with './g/.' should resolve to http://a/b/c/g/" do
-    (@uri + "./g/.").to_s.should == "http://a/b/c/g/"
-    Addressable::URI.join(@uri.to_s, "./g/.").to_s.should == "http://a/b/c/g/"
+    expect((@uri + "./g/.").to_s).to eq("http://a/b/c/g/")
+    expect(Addressable::URI.join(@uri.to_s, "./g/.").to_s).to eq("http://a/b/c/g/")
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with 'g/./h' should resolve to http://a/b/c/g/h" do
-    (@uri + "g/./h").to_s.should == "http://a/b/c/g/h"
-    Addressable::URI.join(@uri.to_s, "g/./h").to_s.should == "http://a/b/c/g/h"
+    expect((@uri + "g/./h").to_s).to eq("http://a/b/c/g/h")
+    expect(Addressable::URI.join(@uri.to_s, "g/./h").to_s).to eq("http://a/b/c/g/h")
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with 'g/../h' should resolve to http://a/b/c/h" do
-    (@uri + "g/../h").to_s.should == "http://a/b/c/h"
-    Addressable::URI.join(@uri.to_s, "g/../h").to_s.should == "http://a/b/c/h"
+    expect((@uri + "g/../h").to_s).to eq("http://a/b/c/h")
+    expect(Addressable::URI.join(@uri.to_s, "g/../h").to_s).to eq("http://a/b/c/h")
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with 'g;x=1/./y' " +
       "should resolve to http://a/b/c/g;x=1/y" do
-    (@uri + "g;x=1/./y").to_s.should == "http://a/b/c/g;x=1/y"
-    Addressable::URI.join(
-      @uri.to_s, "g;x=1/./y").to_s.should == "http://a/b/c/g;x=1/y"
+    expect((@uri + "g;x=1/./y").to_s).to eq("http://a/b/c/g;x=1/y")
+    expect(Addressable::URI.join(
+      @uri.to_s, "g;x=1/./y").to_s).to eq("http://a/b/c/g;x=1/y")
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with 'g;x=1/../y' should resolve to http://a/b/c/y" do
-    (@uri + "g;x=1/../y").to_s.should == "http://a/b/c/y"
-    Addressable::URI.join(
-      @uri.to_s, "g;x=1/../y").to_s.should == "http://a/b/c/y"
+    expect((@uri + "g;x=1/../y").to_s).to eq("http://a/b/c/y")
+    expect(Addressable::URI.join(
+      @uri.to_s, "g;x=1/../y").to_s).to eq("http://a/b/c/y")
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with 'g?y/./x' " +
       "should resolve to http://a/b/c/g?y/./x" do
-    (@uri + "g?y/./x").to_s.should == "http://a/b/c/g?y/./x"
-    Addressable::URI.join(
-      @uri.to_s, "g?y/./x").to_s.should == "http://a/b/c/g?y/./x"
+    expect((@uri + "g?y/./x").to_s).to eq("http://a/b/c/g?y/./x")
+    expect(Addressable::URI.join(
+      @uri.to_s, "g?y/./x").to_s).to eq("http://a/b/c/g?y/./x")
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with 'g?y/../x' " +
       "should resolve to http://a/b/c/g?y/../x" do
-    (@uri + "g?y/../x").to_s.should == "http://a/b/c/g?y/../x"
-    Addressable::URI.join(
-      @uri.to_s, "g?y/../x").to_s.should == "http://a/b/c/g?y/../x"
+    expect((@uri + "g?y/../x").to_s).to eq("http://a/b/c/g?y/../x")
+    expect(Addressable::URI.join(
+      @uri.to_s, "g?y/../x").to_s).to eq("http://a/b/c/g?y/../x")
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with 'g#s/./x' " +
       "should resolve to http://a/b/c/g#s/./x" do
-    (@uri + "g#s/./x").to_s.should == "http://a/b/c/g#s/./x"
-    Addressable::URI.join(
-      @uri.to_s, "g#s/./x").to_s.should == "http://a/b/c/g#s/./x"
+    expect((@uri + "g#s/./x").to_s).to eq("http://a/b/c/g#s/./x")
+    expect(Addressable::URI.join(
+      @uri.to_s, "g#s/./x").to_s).to eq("http://a/b/c/g#s/./x")
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with 'g#s/../x' " +
       "should resolve to http://a/b/c/g#s/../x" do
-    (@uri + "g#s/../x").to_s.should == "http://a/b/c/g#s/../x"
-    Addressable::URI.join(
-      @uri.to_s, "g#s/../x").to_s.should == "http://a/b/c/g#s/../x"
+    expect((@uri + "g#s/../x").to_s).to eq("http://a/b/c/g#s/../x")
+    expect(Addressable::URI.join(
+      @uri.to_s, "g#s/../x").to_s).to eq("http://a/b/c/g#s/../x")
   end
 
   # Section 5.4.2 of RFC 3986
   it "when joined with 'http:g' should resolve to http:g" do
-    (@uri + "http:g").to_s.should == "http:g"
-    Addressable::URI.join(@uri.to_s, "http:g").to_s.should == "http:g"
+    expect((@uri + "http:g").to_s).to eq("http:g")
+    expect(Addressable::URI.join(@uri.to_s, "http:g").to_s).to eq("http:g")
   end
 
   # Edge case to be sure
   it "when joined with '//example.com/' should " +
       "resolve to http://example.com/" do
-    (@uri + "//example.com/").to_s.should == "http://example.com/"
-    Addressable::URI.join(
-      @uri.to_s, "//example.com/").to_s.should == "http://example.com/"
+    expect((@uri + "//example.com/").to_s).to eq("http://example.com/")
+    expect(Addressable::URI.join(
+      @uri.to_s, "//example.com/").to_s).to eq("http://example.com/")
   end
 
   it "when joined with a bogus object a TypeError should be raised" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.join(@uri, 42)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 end
 
@@ -5047,22 +5125,23 @@ describe Addressable::URI, "when converting the path " +
   it "should convert to " +
       "\'relative/path/to/something\'" do
     @uri = Addressable::URI.convert_path(@path)
-    @uri.to_str.should == "relative/path/to/something"
+    expect(@uri.to_str).to eq("relative/path/to/something")
   end
 
   it "should join with an absolute file path correctly" do
     @base = Addressable::URI.convert_path("/absolute/path/")
     @uri = Addressable::URI.convert_path(@path)
-    (@base + @uri).to_str.should ==
+    expect((@base + @uri).to_str).to eq(
       "file:///absolute/path/relative/path/to/something"
+    )
   end
 end
 
 describe Addressable::URI, "when converting a bogus path" do
   it "should raise a TypeError" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.convert_path(42)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 end
 
@@ -5073,12 +5152,12 @@ describe Addressable::URI, "when given a UNIX root directory" do
 
   it "should convert to \'file:///\'" do
     @uri = Addressable::URI.convert_path(@path)
-    @uri.to_str.should == "file:///"
+    expect(@uri.to_str).to eq("file:///")
   end
 
   it "should have an origin of 'file://'" do
     @uri = Addressable::URI.convert_path(@path)
-    @uri.origin.should == 'file://'
+    expect(@uri.origin).to eq('file://')
   end
 end
 
@@ -5089,12 +5168,12 @@ describe Addressable::URI, "when given a Windows root directory" do
 
   it "should convert to \'file:///c:/\'" do
     @uri = Addressable::URI.convert_path(@path)
-    @uri.to_str.should == "file:///c:/"
+    expect(@uri.to_str).to eq("file:///c:/")
   end
 
   it "should have an origin of 'file://'" do
     @uri = Addressable::URI.convert_path(@path)
-    @uri.origin.should == 'file://'
+    expect(@uri.origin).to eq('file://')
   end
 end
 
@@ -5106,12 +5185,12 @@ describe Addressable::URI, "when given the path '/one/two/'" do
   it "should convert to " +
       "\'file:///one/two/\'" do
     @uri = Addressable::URI.convert_path(@path)
-    @uri.to_str.should == "file:///one/two/"
+    expect(@uri.to_str).to eq("file:///one/two/")
   end
 
   it "should have an origin of 'file://'" do
     @uri = Addressable::URI.convert_path(@path)
-    @uri.origin.should == 'file://'
+    expect(@uri.origin).to eq('file://')
   end
 end
 
@@ -5124,12 +5203,12 @@ describe Addressable::URI, "when given the path " +
   it "should convert to " +
       "\'file:///c:/windows/My%20Documents%20100%20/foo.txt\'" do
     @uri = Addressable::URI.convert_path(@path)
-    @uri.to_str.should == "file:///c:/windows/My%20Documents%20100%20/foo.txt"
+    expect(@uri.to_str).to eq("file:///c:/windows/My%20Documents%20100%20/foo.txt")
   end
 
   it "should have an origin of 'file://'" do
     @uri = Addressable::URI.convert_path(@path)
-    @uri.origin.should == 'file://'
+    expect(@uri.origin).to eq('file://')
   end
 end
 
@@ -5142,12 +5221,12 @@ describe Addressable::URI, "when given the path " +
   it "should convert to " +
       "\'file:///c:/windows/My%20Documents%20100%20/foo.txt\'" do
     @uri = Addressable::URI.convert_path(@path)
-    @uri.to_str.should == "file:///c:/windows/My%20Documents%20100%20/foo.txt"
+    expect(@uri.to_str).to eq("file:///c:/windows/My%20Documents%20100%20/foo.txt")
   end
 
   it "should have an origin of 'file://'" do
     @uri = Addressable::URI.convert_path(@path)
-    @uri.origin.should == 'file://'
+    expect(@uri.origin).to eq('file://')
   end
 end
 
@@ -5160,12 +5239,12 @@ describe Addressable::URI, "when given the path " +
   it "should convert to " +
       "\'file:///c:/windows/My%20Documents%20100%20/foo.txt\'" do
     @uri = Addressable::URI.convert_path(@path)
-    @uri.to_str.should == "file:///c:/windows/My%20Documents%20100%20/foo.txt"
+    expect(@uri.to_str).to eq("file:///c:/windows/My%20Documents%20100%20/foo.txt")
   end
 
   it "should have an origin of 'file://'" do
     @uri = Addressable::URI.convert_path(@path)
-    @uri.origin.should == 'file://'
+    expect(@uri.origin).to eq('file://')
   end
 end
 
@@ -5178,12 +5257,12 @@ describe Addressable::URI, "when given the path " +
   it "should convert to " +
       "\'file:///c:/windows/My%20Documents%20100%20/foo.txt\'" do
     @uri = Addressable::URI.convert_path(@path)
-    @uri.to_str.should == "file:///c:/windows/My%20Documents%20100%20/foo.txt"
+    expect(@uri.to_str).to eq("file:///c:/windows/My%20Documents%20100%20/foo.txt")
   end
 
   it "should have an origin of 'file://'" do
     @uri = Addressable::URI.convert_path(@path)
-    @uri.origin.should == 'file://'
+    expect(@uri.origin).to eq('file://')
   end
 end
 
@@ -5196,12 +5275,12 @@ describe Addressable::URI, "when given the path " +
   it "should convert to " +
       "\'file:///c:/windows/My%20Documents%20100%20/foo.txt\'" do
     @uri = Addressable::URI.convert_path(@path)
-    @uri.to_str.should == "file:///c:/windows/My%20Documents%20100%20/foo.txt"
+    expect(@uri.to_str).to eq("file:///c:/windows/My%20Documents%20100%20/foo.txt")
   end
 
   it "should have an origin of 'file://'" do
     @uri = Addressable::URI.convert_path(@path)
-    @uri.origin.should == 'file://'
+    expect(@uri.origin).to eq('file://')
   end
 end
 
@@ -5212,7 +5291,7 @@ describe Addressable::URI, "when given an http protocol URI" do
 
   it "should not do any conversion at all" do
     @uri = Addressable::URI.convert_path(@path)
-    @uri.to_str.should == "http://example.com/"
+    expect(@uri.to_str).to eq("http://example.com/")
   end
 end
 
@@ -5232,9 +5311,9 @@ describe Addressable::URI, "when parsing a non-String object" do
   end
 
   it "should raise a TypeError for objects than cannot be converted" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.parse(42)
-    end).should raise_error(TypeError, "Can't convert Fixnum into String.")
+    end).to raise_error(TypeError, "Can't convert Fixnum into String.")
   end
 
   it "should correctly parse heuristically anything with a 'to_str' method" do
@@ -5242,92 +5321,93 @@ describe Addressable::URI, "when parsing a non-String object" do
   end
 
   it "should raise a TypeError for objects than cannot be converted" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.heuristic_parse(42)
-    end).should raise_error(TypeError, "Can't convert Fixnum into String.")
+    end).to raise_error(TypeError, "Can't convert Fixnum into String.")
   end
 end
 
 describe Addressable::URI, "when form encoding a hash" do
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.form_encode(
+    expect(Addressable::URI.form_encode(
       [["&one", "/1"], ["=two", "?2"], [":three", "#3"]]
-    ).should == "%26one=%2F1&%3Dtwo=%3F2&%3Athree=%233"
+    )).to eq("%26one=%2F1&%3Dtwo=%3F2&%3Athree=%233")
   end
 
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.form_encode(
+    expect(Addressable::URI.form_encode(
       {"q" => "one two three"}
-    ).should == "q=one+two+three"
+    )).to eq("q=one+two+three")
   end
 
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.form_encode(
+    expect(Addressable::URI.form_encode(
       {"key" => nil}
-    ).should == "key="
+    )).to eq("key=")
   end
 
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.form_encode(
+    expect(Addressable::URI.form_encode(
       {"q" => ["one", "two", "three"]}
-    ).should == "q=one&q=two&q=three"
+    )).to eq("q=one&q=two&q=three")
   end
 
   it "should result in correctly encoded newlines" do
-    Addressable::URI.form_encode(
+    expect(Addressable::URI.form_encode(
       {"text" => "one\ntwo\rthree\r\nfour\n\r"}
-    ).should == "text=one%0D%0Atwo%0D%0Athree%0D%0Afour%0D%0A%0D%0A"
+    )).to eq("text=one%0D%0Atwo%0D%0Athree%0D%0Afour%0D%0A%0D%0A")
   end
 
   it "should result in a sorted percent encoded sequence" do
-    Addressable::URI.form_encode(
+    expect(Addressable::URI.form_encode(
       [["a", "1"], ["dup", "3"], ["dup", "2"]], true
-    ).should == "a=1&dup=2&dup=3"
+    )).to eq("a=1&dup=2&dup=3")
   end
 end
 
 describe Addressable::URI, "when form encoding a non-Array object" do
   it "should raise a TypeError for objects than cannot be converted" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.form_encode(42)
-    end).should raise_error(TypeError, "Can't convert Fixnum into Array.")
+    end).to raise_error(TypeError, "Can't convert Fixnum into Array.")
   end
 end
 
 describe Addressable::URI, "when form unencoding a string" do
   it "should result in correct values" do
-    Addressable::URI.form_unencode(
+    expect(Addressable::URI.form_unencode(
       "%26one=%2F1&%3Dtwo=%3F2&%3Athree=%233"
-    ).should == [["&one", "/1"], ["=two", "?2"], [":three", "#3"]]
+    )).to eq([["&one", "/1"], ["=two", "?2"], [":three", "#3"]])
   end
 
   it "should result in correct values" do
-    Addressable::URI.form_unencode(
+    expect(Addressable::URI.form_unencode(
       "q=one+two+three"
-    ).should == [["q", "one two three"]]
+    )).to eq([["q", "one two three"]])
   end
 
   it "should result in correct values" do
-    Addressable::URI.form_unencode(
+    expect(Addressable::URI.form_unencode(
       "text=one%0D%0Atwo%0D%0Athree%0D%0Afour%0D%0A%0D%0A"
-    ).should == [["text", "one\ntwo\nthree\nfour\n\n"]]
+    )).to eq([["text", "one\ntwo\nthree\nfour\n\n"]])
   end
 
   it "should result in correct values" do
-    Addressable::URI.form_unencode(
+    expect(Addressable::URI.form_unencode(
       "a=1&dup=2&dup=3"
-    ).should == [["a", "1"], ["dup", "2"], ["dup", "3"]]
+    )).to eq([["a", "1"], ["dup", "2"], ["dup", "3"]])
   end
 
   it "should result in correct values" do
-    Addressable::URI.form_unencode(
+    expect(Addressable::URI.form_unencode(
       "key"
-    ).should == [["key", nil]]
+    )).to eq([["key", nil]])
   end
 
   it "should result in correct values" do
-    Addressable::URI.form_unencode("GivenName=Ren%C3%A9").should ==
+    expect(Addressable::URI.form_unencode("GivenName=Ren%C3%A9")).to eq(
       [["GivenName", "René"]]
+    )
   end
 end
 
@@ -5337,9 +5417,9 @@ describe Addressable::URI, "when form unencoding a non-String object" do
   end
 
   it "should raise a TypeError for objects than cannot be converted" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.form_unencode(42)
-    end).should raise_error(TypeError, "Can't convert Fixnum into String.")
+    end).to raise_error(TypeError, "Can't convert Fixnum into String.")
   end
 end
 
@@ -5349,69 +5429,73 @@ describe Addressable::URI, "when normalizing a non-String object" do
   end
 
   it "should raise a TypeError for objects than cannot be converted" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.normalize_component(42)
-    end).should raise_error(TypeError, "Can't convert Fixnum into String.")
+    end).to raise_error(TypeError, "Can't convert Fixnum into String.")
   end
 
   it "should raise a TypeError for objects than cannot be converted" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.normalize_component("component", 42)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 end
 
 describe Addressable::URI, "when normalizing a path with an encoded slash" do
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.parse("/path%2Fsegment/").normalize.path.should ==
+    expect(Addressable::URI.parse("/path%2Fsegment/").normalize.path).to eq(
       "/path%2Fsegment/"
+    )
   end
 end
 
 describe Addressable::URI, "when normalizing a partially encoded string" do
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.normalize_component(
+    expect(Addressable::URI.normalize_component(
       "partially % encoded%21"
-    ).should == "partially%20%25%20encoded!"
+    )).to eq("partially%20%25%20encoded!")
   end
 
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.normalize_component(
+    expect(Addressable::URI.normalize_component(
       "partially %25 encoded!"
-    ).should == "partially%20%25%20encoded!"
+    )).to eq("partially%20%25%20encoded!")
   end
 end
 
 describe Addressable::URI, "when normalizing a unicode sequence" do
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.normalize_component(
+    expect(Addressable::URI.normalize_component(
       "/C%CC%A7"
-    ).should == "/%C3%87"
+    )).to eq("/%C3%87")
   end
 
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.normalize_component(
+    expect(Addressable::URI.normalize_component(
       "/%C3%87"
-    ).should == "/%C3%87"
+    )).to eq("/%C3%87")
   end
 end
 
 describe Addressable::URI, "when normalizing a multibyte string" do
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.normalize_component("günther").should ==
+    expect(Addressable::URI.normalize_component("günther")).to eq(
       "g%C3%BCnther"
+    )
   end
 
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.normalize_component("g%C3%BCnther").should ==
+    expect(Addressable::URI.normalize_component("g%C3%BCnther")).to eq(
       "g%C3%BCnther"
+    )
   end
 end
 
 describe Addressable::URI, "when normalizing a string but leaving some characters encoded" do
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.normalize_component("%58X%59Y%5AZ", "0-9a-zXY", "Y").should ==
+    expect(Addressable::URI.normalize_component("%58X%59Y%5AZ", "0-9a-zXY", "Y")).to eq(
       "XX%59Y%5A%5A"
+    )
   end
 
   it "should not modify the character class" do
@@ -5421,116 +5505,117 @@ describe Addressable::URI, "when normalizing a string but leaving some character
 
     Addressable::URI.normalize_component("%58X%59Y%5AZ", character_class, "Y")
 
-    character_class.should == character_class_copy
+    expect(character_class).to eq(character_class_copy)
   end
 end
 
 describe Addressable::URI, "when encoding a string with existing encodings to upcase" do
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.encode_component("JK%4c", "0-9A-IKM-Za-z%", "L").should == "%4AK%4C"
+    expect(Addressable::URI.encode_component("JK%4c", "0-9A-IKM-Za-z%", "L")).to eq("%4AK%4C")
   end
 end
 
 describe Addressable::URI, "when encoding a multibyte string" do
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.encode_component("günther").should == "g%C3%BCnther"
+    expect(Addressable::URI.encode_component("günther")).to eq("g%C3%BCnther")
   end
 
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.encode_component(
+    expect(Addressable::URI.encode_component(
       "günther", /[^a-zA-Z0-9\:\/\?\#\[\]\@\!\$\&\'\(\)\*\+\,\;\=\-\.\_\~]/
-    ).should == "g%C3%BCnther"
+    )).to eq("g%C3%BCnther")
   end
 end
 
 describe Addressable::URI, "when form encoding a multibyte string" do
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.form_encode({"GivenName" => "René"}).should ==
+    expect(Addressable::URI.form_encode({"GivenName" => "René"})).to eq(
       "GivenName=Ren%C3%A9"
+    )
   end
 end
 
 describe Addressable::URI, "when encoding a string with ASCII chars 0-15" do
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.encode_component("one\ntwo").should == "one%0Atwo"
+    expect(Addressable::URI.encode_component("one\ntwo")).to eq("one%0Atwo")
   end
 
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.encode_component(
+    expect(Addressable::URI.encode_component(
       "one\ntwo", /[^a-zA-Z0-9\:\/\?\#\[\]\@\!\$\&\'\(\)\*\+\,\;\=\-\.\_\~]/
-    ).should == "one%0Atwo"
+    )).to eq("one%0Atwo")
   end
 end
 
 describe Addressable::URI, "when unencoding a multibyte string" do
   it "should result in correct percent encoded sequence" do
-    Addressable::URI.unencode_component("g%C3%BCnther").should == "günther"
+    expect(Addressable::URI.unencode_component("g%C3%BCnther")).to eq("günther")
   end
 
   it "should consistently use UTF-8 internally" do
-    Addressable::URI.unencode_component("ski=%BA%DAɫ").should == "ski=\xBA\xDAɫ"
+    expect(Addressable::URI.unencode_component("ski=%BA%DAɫ")).to eq("ski=\xBA\xDAɫ")
   end
 
   it "should result in correct percent encoded sequence as a URI" do
-    Addressable::URI.unencode(
+    expect(Addressable::URI.unencode(
       "/path?g%C3%BCnther", ::Addressable::URI
-    ).should == Addressable::URI.new(
+    )).to eq(Addressable::URI.new(
       :path => "/path", :query => "günther"
-    )
+    ))
   end
 end
 
 describe Addressable::URI, "when partially unencoding a string" do
   it "should unencode all characters by default" do
-    Addressable::URI.unencode('%%25~%7e+%2b', String).should == '%%~~++'
+    expect(Addressable::URI.unencode('%%25~%7e+%2b', String)).to eq('%%~~++')
   end
 
   it "should unencode characters not in leave_encoded" do
-    Addressable::URI.unencode('%%25~%7e+%2b', String, '~').should == '%%~%7e++'
+    expect(Addressable::URI.unencode('%%25~%7e+%2b', String, '~')).to eq('%%~%7e++')
   end
 
   it "should leave characters in leave_encoded alone" do
-    Addressable::URI.unencode('%%25~%7e+%2b', String, '%~+').should == '%%25~%7e+%2b'
+    expect(Addressable::URI.unencode('%%25~%7e+%2b', String, '%~+')).to eq('%%25~%7e+%2b')
   end
 end
 
 describe Addressable::URI, "when unencoding a bogus object" do
   it "should raise a TypeError" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.unencode_component(42)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "should raise a TypeError" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.unencode("/path?g%C3%BCnther", Integer)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 end
 
 describe Addressable::URI, "when encoding a bogus object" do
   it "should raise a TypeError" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.encode(Object.new)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "should raise a TypeError" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.normalized_encode(Object.new)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "should raise a TypeError" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.encode_component("günther", Object.new)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "should raise a TypeError" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.encode_component(Object.new)
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 end
 
@@ -5542,13 +5627,13 @@ describe Addressable::URI, "when given the input " +
 
   it "should heuristically parse to 'http://example.com/'" do
     @uri = Addressable::URI.heuristic_parse(@input)
-    @uri.to_s.should == "http://example.com/"
+    expect(@uri.to_s).to eq("http://example.com/")
   end
 
   it "should not raise error when frozen" do
-    (lambda do
+    expect(lambda do
       Addressable::URI.heuristic_parse(@input).freeze.to_s
-    end).should_not raise_error
+    end).not_to raise_error
   end
 end
 
@@ -5560,7 +5645,7 @@ describe Addressable::URI, "when given the input " +
 
   it "should heuristically parse to 'https://example.com/'" do
     @uri = Addressable::URI.heuristic_parse(@input)
-    @uri.to_s.should == "https://example.com/"
+    expect(@uri.to_s).to eq("https://example.com/")
   end
 end
 
@@ -5572,13 +5657,13 @@ describe Addressable::URI, "when given the input " +
 
   it "should heuristically parse to 'http://example.com/'" do
     @uri = Addressable::URI.heuristic_parse(@input)
-    @uri.to_s.should == "http://example.com/"
+    expect(@uri.to_s).to eq("http://example.com/")
   end
 
   it "should heuristically parse to 'http://example.com/' " +
       "even with a scheme hint of 'ftp'" do
     @uri = Addressable::URI.heuristic_parse(@input, {:scheme => 'ftp'})
-    @uri.to_s.should == "http://example.com/"
+    expect(@uri.to_s).to eq("http://example.com/")
   end
 end
 
@@ -5590,13 +5675,13 @@ describe Addressable::URI, "when given the input " +
 
   it "should heuristically parse to 'https://example.com/'" do
     @uri = Addressable::URI.heuristic_parse(@input)
-    @uri.to_s.should == "https://example.com/"
+    expect(@uri.to_s).to eq("https://example.com/")
   end
 
   it "should heuristically parse to 'https://example.com/' " +
       "even with a scheme hint of 'ftp'" do
     @uri = Addressable::URI.heuristic_parse(@input, {:scheme => 'ftp'})
-    @uri.to_s.should == "https://example.com/"
+    expect(@uri.to_s).to eq("https://example.com/")
   end
 end
 
@@ -5608,7 +5693,7 @@ describe Addressable::URI, "when given the input " +
 
   it "should heuristically parse to 'http://example.com/example.com/'" do
     @uri = Addressable::URI.heuristic_parse(@input)
-    @uri.to_s.should == "http://example.com/example.com/"
+    expect(@uri.to_s).to eq("http://example.com/example.com/")
   end
 end
 
@@ -5620,7 +5705,7 @@ describe Addressable::URI, "when given the input " +
 
   it "should heuristically parse to '/path/to/resource'" do
     @uri = Addressable::URI.heuristic_parse(@input)
-    @uri.to_s.should == "/path/to/resource"
+    expect(@uri.to_s).to eq("/path/to/resource")
   end
 end
 
@@ -5632,7 +5717,7 @@ describe Addressable::URI, "when given the input " +
 
   it "should heuristically parse to 'relative/path/to/resource'" do
     @uri = Addressable::URI.heuristic_parse(@input)
-    @uri.to_s.should == "relative/path/to/resource"
+    expect(@uri.to_s).to eq("relative/path/to/resource")
   end
 end
 
@@ -5644,7 +5729,7 @@ describe Addressable::URI, "when given the input " +
 
   it "should heuristically parse to 'http://example.com'" do
     @uri = Addressable::URI.heuristic_parse(@input)
-    @uri.to_s.should == "http://example.com"
+    expect(@uri.to_s).to eq("http://example.com")
   end
 end
 
@@ -5657,7 +5742,7 @@ describe Addressable::URI, "when given the input " +
 
   it "should heuristically parse to 'http://example.com'" do
     @uri = Addressable::URI.heuristic_parse(@input, @hints)
-    @uri.to_s.should == "ftp://example.com"
+    expect(@uri.to_s).to eq("ftp://example.com")
   end
 end
 
@@ -5670,7 +5755,7 @@ describe Addressable::URI, "when given the input " +
 
   it "should heuristically parse to 'http://example.com:21'" do
     @uri = Addressable::URI.heuristic_parse(@input, @hints)
-    @uri.to_s.should == "ftp://example.com:21"
+    expect(@uri.to_s).to eq("ftp://example.com:21")
   end
 end
 
@@ -5682,7 +5767,7 @@ describe Addressable::URI, "when given the input " +
 
   it "should heuristically parse to 'http://example.com/path/to/resource'" do
     @uri = Addressable::URI.heuristic_parse(@input)
-    @uri.to_s.should == "http://example.com/path/to/resource"
+    expect(@uri.to_s).to eq("http://example.com/path/to/resource")
   end
 end
 
@@ -5694,7 +5779,7 @@ describe Addressable::URI, "when given the input " +
 
   it "should heuristically parse to 'http://example.com'" do
     @uri = Addressable::URI.heuristic_parse(@input)
-    @uri.to_s.should == "http://example.com"
+    expect(@uri.to_s).to eq("http://example.com")
   end
 end
 
@@ -5706,7 +5791,7 @@ describe Addressable::URI, "when given the input " +
 
   it "should heuristically parse to 'feed://example.com'" do
     @uri = Addressable::URI.heuristic_parse(@input)
-    @uri.to_s.should == "feed://example.com"
+    expect(@uri.to_s).to eq("feed://example.com")
   end
 end
 
@@ -5718,7 +5803,7 @@ describe Addressable::URI, "when given the input " +
 
   it "should heuristically parse to 'file:///path/to/resource/'" do
     @uri = Addressable::URI.heuristic_parse(@input)
-    @uri.to_s.should == "file:///path/to/resource/"
+    expect(@uri.to_s).to eq("file:///path/to/resource/")
   end
 end
 
@@ -5730,7 +5815,7 @@ describe Addressable::URI, "when given the input " +
 
   it "should heuristically parse to 'feed:http://example.com'" do
     @uri = Addressable::URI.heuristic_parse(@input)
-    @uri.to_s.should == "feed:http://example.com"
+    expect(@uri.to_s).to eq("feed:http://example.com")
   end
 end
 
@@ -5742,7 +5827,7 @@ describe Addressable::URI, "when given the input " +
 
   it "should heuristically parse to 'http://example.com'" do
     @uri = Addressable::URI.heuristic_parse(@input)
-    @uri.to_s.should == "http://example.com"
+    expect(@uri.to_s).to eq("http://example.com")
   end
 end
 
@@ -5753,97 +5838,97 @@ describe Addressable::URI, "when assigning query values" do
 
   it "should correctly assign {:a => 'a', :b => ['c', 'd', 'e']}" do
     @uri.query_values = {:a => "a", :b => ["c", "d", "e"]}
-    @uri.query.should == "a=a&b=c&b=d&b=e"
+    expect(@uri.query).to eq("a=a&b=c&b=d&b=e")
   end
 
   it "should raise an error attempting to assign {'a' => {'b' => ['c']}}" do
-    (lambda do
+    expect(lambda do
       @uri.query_values = { 'a' => {'b' => ['c'] } }
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "should raise an error attempting to assign " +
       "{:b => '2', :a => {:c => '1'}}" do
-    (lambda do
+    expect(lambda do
       @uri.query_values = {:b => '2', :a => {:c => '1'}}
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "should raise an error attempting to assign " +
       "{:a => 'a', :b => [{:c => 'c', :d => 'd'}, " +
       "{:e => 'e', :f => 'f'}]}" do
-    (lambda do
+    expect(lambda do
       @uri.query_values = {
         :a => "a", :b => [{:c => "c", :d => "d"}, {:e => "e", :f => "f"}]
       }
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "should raise an error attempting to assign " +
       "{:a => 'a', :b => [{:c => true, :d => 'd'}, " +
       "{:e => 'e', :f => 'f'}]}" do
-    (lambda do
+    expect(lambda do
       @uri.query_values = {
         :a => 'a', :b => [{:c => true, :d => 'd'}, {:e => 'e', :f => 'f'}]
       }
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "should raise an error attempting to assign " +
       "{:a => 'a', :b => {:c => true, :d => 'd'}}" do
-    (lambda do
+    expect(lambda do
       @uri.query_values = {
         :a => 'a', :b => {:c => true, :d => 'd'}
       }
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "should raise an error attempting to assign " +
       "{:a => 'a', :b => {:c => true, :d => 'd'}}" do
-    (lambda do
+    expect(lambda do
       @uri.query_values = {
         :a => 'a', :b => {:c => true, :d => 'd'}
       }
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "should correctly assign {:a => 1, :b => 1.5}" do
     @uri.query_values = { :a => 1, :b => 1.5 }
-    @uri.query.should == "a=1&b=1.5"
+    expect(@uri.query).to eq("a=1&b=1.5")
   end
 
   it "should raise an error attempting to assign " +
       "{:z => 1, :f => [2, {999.1 => [3,'4']}, ['h', 'i']], " +
       ":a => {:b => ['c', 'd'], :e => true, :y => 0.5}}" do
-    (lambda do
+    expect(lambda do
       @uri.query_values = {
         :z => 1,
         :f => [ 2, {999.1 => [3,'4']}, ['h', 'i'] ],
         :a => { :b => ['c', 'd'], :e => true, :y => 0.5 }
       }
-    end).should raise_error(TypeError)
+    end).to raise_error(TypeError)
   end
 
   it "should correctly assign {}" do
     @uri.query_values = {}
-    @uri.query.should == ''
+    expect(@uri.query).to eq('')
   end
 
   it "should correctly assign nil" do
     @uri.query_values = nil
-    @uri.query.should == nil
+    expect(@uri.query).to eq(nil)
   end
 
   it "should correctly sort {'ab' => 'c', :ab => 'a', :a => 'x'}" do
     @uri.query_values = {'ab' => 'c', :ab => 'a', :a => 'x'}
-    @uri.query.should == "a=x&ab=a&ab=c"
+    expect(@uri.query).to eq("a=x&ab=a&ab=c")
   end
 
   it "should correctly assign " +
       "[['b', 'c'], ['b', 'a'], ['a', 'a']]" do
     # Order can be guaranteed in this format, so preserve it.
     @uri.query_values = [['b', 'c'], ['b', 'a'], ['a', 'a']]
-    @uri.query.should == "b=c&b=a&a=a"
+    expect(@uri.query).to eq("b=c&b=a&a=a")
   end
 
   it "should preserve query string order" do
@@ -5851,14 +5936,13 @@ describe Addressable::URI, "when assigning query values" do
     @uri.query = query_string
     original_uri = @uri.to_s
     @uri.query_values = @uri.query_values(Array)
-    @uri.to_s.should == original_uri
+    expect(@uri.to_s).to eq(original_uri)
   end
 
   describe 'when a hash with mixed types is assigned to query_values' do
     it 'should not raise an error' do
-      pending 'Issue #94' do
-        expect { subject.query_values = { "page" => "1", :page => 2 } }.to_not raise_error
-      end
+      skip 'Issue #94'
+      expect { subject.query_values = { "page" => "1", :page => 2 } }.to_not raise_error
     end
   end
 end
@@ -5870,9 +5954,9 @@ describe Addressable::URI, "when assigning path values" do
 
   it "should correctly assign paths containing colons" do
     @uri.path = "acct:bob@sporkmonger.com"
-    @uri.path.should == "acct:bob@sporkmonger.com"
-    @uri.normalize.to_str.should == "acct%2Fbob@sporkmonger.com"
-    (lambda { @uri.to_s }).should raise_error(
+    expect(@uri.path).to eq("acct:bob@sporkmonger.com")
+    expect(@uri.normalize.to_str).to eq("acct%2Fbob@sporkmonger.com")
+    expect(lambda { @uri.to_s }).to raise_error(
       Addressable::URI::InvalidURIError
     )
   end
@@ -5880,36 +5964,36 @@ describe Addressable::URI, "when assigning path values" do
   it "should correctly assign paths containing colons" do
     @uri.path = "/acct:bob@sporkmonger.com"
     @uri.authority = "example.com"
-    @uri.normalize.to_str.should == "//example.com/acct:bob@sporkmonger.com"
+    expect(@uri.normalize.to_str).to eq("//example.com/acct:bob@sporkmonger.com")
   end
 
   it "should correctly assign paths containing colons" do
     @uri.path = "acct:bob@sporkmonger.com"
     @uri.scheme = "something"
-    @uri.normalize.to_str.should == "something:acct:bob@sporkmonger.com"
+    expect(@uri.normalize.to_str).to eq("something:acct:bob@sporkmonger.com")
   end
 
   it "should not allow relative paths to be assigned on absolute URIs" do
-    (lambda do
+    expect(lambda do
       @uri.scheme = "http"
       @uri.host = "example.com"
       @uri.path = "acct:bob@sporkmonger.com"
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 
   it "should not allow relative paths to be assigned on absolute URIs" do
-    (lambda do
+    expect(lambda do
       @uri.path = "acct:bob@sporkmonger.com"
       @uri.scheme = "http"
       @uri.host = "example.com"
-    end).should raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 
   it "should not allow relative paths to be assigned on absolute URIs" do
-    (lambda do
+    expect(lambda do
       @uri.path = "uuid:0b3ecf60-3f93-11df-a9c3-001f5bfffe12"
       @uri.scheme = "urn"
-    end).should_not raise_error
+    end).not_to raise_error
   end
 end
 
@@ -5919,22 +6003,22 @@ describe Addressable::URI, "when initializing a subclass of Addressable::URI" do
   end
 
   it "should have the same class after being parsed" do
-    @uri.class.should == Addressable::URI.parse(@uri).class
+    expect(@uri.class).to eq(Addressable::URI.parse(@uri).class)
   end
 
   it "should have the same class as its duplicate" do
-    @uri.class.should == @uri.dup.class
+    expect(@uri.class).to eq(@uri.dup.class)
   end
 
   it "should have the same class after being normalized" do
-    @uri.class.should == @uri.normalize.class
+    expect(@uri.class).to eq(@uri.normalize.class)
   end
 
   it "should have the same class after being merged" do
-    @uri.class.should == @uri.merge(:path => 'path').class
+    expect(@uri.class).to eq(@uri.merge(:path => 'path').class)
   end
 
   it "should have the same class after being joined" do
-    @uri.class.should == @uri.join('path').class
+    expect(@uri.class).to eq(@uri.join('path').class)
   end
 end


### PR DESCRIPTION
1. Ran transpec to convert the specs to RSpec 3.0.x syntax
2. Fixed a couple of RSpec deprecation warnings by changing `pending` to `skip`
3. Fixed an issue which was causing the build to fail.  Recent versions of Coveralls no longer support Ruby 1.8.7, so the Coveralls gem should only be included on 1.9+ platforms.

After these changes the build runs green for all required platforms, and it should be trivial to upgrade to RSpec 3.x.