### PR TITLE
Simplify gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,15 @@
 source 'https://rubygems.org'
 
+gemspec
+
 group :development do
-  gem 'launchy'
   gem 'yard'
   gem 'redcarpet', :platform => :mri_19
   gem 'rubyforge'
 end
 
 group :test, :development do
-  gem 'rake', '>= 0.7.3'
-  gem 'rspec', '>= 2.9.0'
-  gem 'coveralls', :require => false
+  gem 'coveralls', :require => false, :platforms => [:ruby_19, :ruby_20, :ruby_21, :rbx, :jruby]
 end
 
 gem 'idn', :platform => :mri_18
@@ -24,5 +23,3 @@ platforms :rbx do
   gem 'rubysl', '~> 2.0'
   gem 'rubinius-coverage'
 end
-
-gemspec

--- a/addressable.gemspec
+++ b/addressable.gemspec
@@ -20,21 +20,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = "2.2.2"
   s.summary = "URI Implementation"
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 4
-
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<rake>, [">= 0.7.3"])
-      s.add_development_dependency(%q<rspec>, [">= 2.9.0", "~> 2.9"])
-      s.add_development_dependency(%q<launchy>, [">= 0.3.2"])
-    else
-      s.add_dependency(%q<rake>, [">= 0.7.3"])
-      s.add_dependency(%q<rspec>, [">= 2.9.0", "~> 2.9"])
-      s.add_dependency(%q<launchy>, [">= 0.3.2"])
-    end
-  else
-    s.add_dependency(%q<rake>, [">= 0.7.3"])
-    s.add_dependency(%q<rspec>, [">= 2.9.0", "~> 2.9"])
-    s.add_dependency(%q<launchy>, [">= 0.3.2"])
-  end
+  s.add_development_dependency(%q<rake>, [">= 0.7.3"])
+  s.add_development_dependency(%q<rspec>, [">= 2.9.0", "~> 2.9"])
+  s.add_development_dependency(%q<launchy>, [">= 0.3.2"])
 end


### PR DESCRIPTION
Simplify the gemspec a bit.  Eliminate duplicate gem declaration warnings.  Also includes the platforms setting that gets the build to green.