### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@
 [![Build Status](https://secure.travis-ci.org/sporkmonger/addressable.png?branch=master)][travis]
 [![Dependency Status](https://gemnasium.com/sporkmonger/addressable.png?travis)][gemnasium]
 [![Coverage Status](https://coveralls.io/repos/sporkmonger/addressable/badge.png?branch=master)][coveralls]
+[![Inline docs](http://inch-ci.org/github/sporkmonger/addressable.png?branch=master)](inchci)
 [![Gittip Donate](http://img.shields.io/gittip/sporkmonger.png)](https://www.gittip.com/sporkmonger/ "Support Open Source Development w/ Gittip")
 
 [gem]: https://rubygems.org/gems/addressable
 [travis]: http://travis-ci.org/sporkmonger/addressable
 [gemnasium]: https://gemnasium.com/sporkmonger/addressable
 [coveralls]: https://coveralls.io/r/sporkmonger/addressable
+[inchci]: http://inch-ci.org/github/sporkmonger/addressable
 
 # Description
 


### PR DESCRIPTION
Hi there,

I noticed that you looked at Inch CI a while ago, but I had a bug in my server that prevented your status page from being build.

[![Inline docs](http://inch-ci.org/github/sporkmonger/addressable.png)](http://inch-ci.org/github/sporkmonger/addressable)

The badge - as you might know - links to [Inch CI](http://inch-ci.org), a project that tries to raise the visibility of inline-docs to encourage aspiring Rubyists to document their code. Your status page is http://inch-ci.org/github/sporkmonger/addressable/

I just wanted to point out that it works now. If you are interested in sporting this badge in your README, you can accept this PR, if not, no hurt feelings. :smiley: 