### PR TITLE
Fix typo in Addressable::Template extract example in README. Fixes #164

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,9 @@ end
 
 group :test, :development do
   gem 'rake', '>= 0.7.3'
-  gem 'rspec', '>= 2.9.0'
+  gem 'rspec', '~> 2.99'
   gem 'coveralls', :require => false
+  gem 'rest-client', '~> 1.6.8'
 end
 
 gem 'idn', :platform => :mri_18

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ template.partial_expand({"one" => "1", "three" => 3}).pattern
 #=> "http://example.com/?one=1{&two}&three=3"
 
 template = Addressable::Template.new(
-  "http://{host}{/segments}/{?one,two,bogus}{#fragment}"
+  "http://{host}{/segments*}/{?one,two,bogus}{#fragment}"
 )
 uri = Addressable::URI.parse(
   "http://example.com/a/b/c/?one=1&two=2#foo"


### PR DESCRIPTION
I'm not too proud to say I've spend a good part of an hour tracking this one down. Turns out the issue that was confusing in #164 is a simple missing asterisk in the README example pattern.

P.S.: You should perhaps lock the version of RSpec to 2.11, as the >= 2.9 dependency specification in the Gemfile will just install 3.x by default, which doesn't work. But then 2.9 doesn't work either (because of `subject` and `expect` API changes).

