### PR TITLE
Memoize Addressable::URI instance variables

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -839,7 +839,8 @@ module Addressable
     #
     # @return [String] The scheme component, normalized.
     def normalized_scheme
-      self.scheme && @normalized_scheme ||= begin
+      return nil unless self.scheme
+      @normalized_scheme ||= begin
         if self.scheme =~ /^\s*ssh\+svn\s*$/i
           "svn+ssh"
         else
@@ -888,7 +889,9 @@ module Addressable
     #
     # @return [String] The user component, normalized.
     def normalized_user
-      self.user && @normalized_user ||= begin
+      return nil unless self.user
+      return @normalized_user if defined?(@normalized_user)
+      @normalized_user ||= begin
         if normalized_scheme =~ /https?/ && self.user.strip.empty? &&
             (!self.password || self.password.strip.empty?)
           nil
@@ -940,7 +943,9 @@ module Addressable
     #
     # @return [String] The password component, normalized.
     def normalized_password
-      self.password && @normalized_password ||= begin
+      return nil unless self.password
+      return @normalized_password if defined?(@normalized_password)
+      @normalized_password ||= begin
         if self.normalized_scheme =~ /https?/ && self.password.strip.empty? &&
             (!self.user || self.user.strip.empty?)
           nil
@@ -1003,7 +1008,9 @@ module Addressable
     #
     # @return [String] The userinfo component, normalized.
     def normalized_userinfo
-      self.userinfo && @normalized_userinfo ||= begin
+      return nil unless self.userinfo
+      return @normalized_userinfo if defined?(@normalized_userinfo)
+      @normalized_userinfo ||= begin
         current_user = self.normalized_user
         current_password = self.normalized_password
         if !current_user && !current_password
@@ -1058,7 +1065,8 @@ module Addressable
     #
     # @return [String] The host component, normalized.
     def normalized_host
-      self.host && @normalized_host ||= begin
+      return nil unless self.host
+      @normalized_host ||= begin
         if !self.host.strip.empty?
           result = ::Addressable::IDNA.to_ascii(
             URI.unencode_component(self.host.strip.downcase)
@@ -1156,7 +1164,8 @@ module Addressable
     #
     # @return [String] The authority component, normalized.
     def normalized_authority
-      self.authority && @normalized_authority ||= begin
+      return nil unless self.authority
+      @normalized_authority ||= begin
         authority = ""
         if self.normalized_userinfo != nil
           authority << "#{self.normalized_userinfo}@"
@@ -1339,7 +1348,8 @@ module Addressable
     #
     # @return [String] The normalized components that identify a site.
     def normalized_site
-      self.site && @normalized_site ||= begin
+      return nil unless self.site
+      @normalized_site ||= begin
         site_string = ""
         if self.normalized_scheme != nil
           site_string << "#{self.normalized_scheme}:"
@@ -1652,7 +1662,7 @@ module Addressable
     #
     # @return [String] The fragment component, normalized.
     def normalized_fragment
-      return unless self.fragment
+      return nil unless self.fragment
       return @normalized_fragment if defined?(@normalized_fragment)
       @normalized_fragment ||= begin
         component = Addressable::URI.normalize_component(
@@ -2096,7 +2106,7 @@ module Addressable
     #
     # @return [Integer] A hash of the URI.
     def hash
-      return @hash ||= self.to_s.hash * -1
+      @hash ||= self.to_s.hash * -1
     end
 
     ##

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1664,13 +1664,15 @@ module Addressable
     #
     # @return [String] The fragment component, normalized.
     def normalized_fragment
-      self.fragment && @normalized_fragment ||= (begin
+      return unless self.fragment
+      return @normalized_fragment if instance_variable_defined?(:@normalized_fragment)
+      @normalized_fragment ||= begin
         component = Addressable::URI.normalize_component(
           self.fragment,
           Addressable::URI::CharacterClasses::FRAGMENT
         )
         component == "" ? nil : component
-      end)
+      end
     end
 
     ##
@@ -1684,9 +1686,9 @@ module Addressable
       @fragment = new_fragment ? new_fragment.to_str : nil
 
       # Reset dependant values
-      @normalized_fragment = nil
-      @uri_string = nil
-      @hash = nil
+      remove_instance_variable(:@normalized_fragment) if instance_variable_defined?(:@normalized_fragment)
+      remove_instance_variable(:@uri_string) if instance_variable_defined?(:@uri_string)
+      remove_instance_variable(:@hash) if instance_variable_defined?(:@hash)
 
       # Ensure we haven't created an invalid URI
       validate()

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -869,8 +869,7 @@ module Addressable
 
       # Reset dependent values
       remove_instance_variable(:@normalized_scheme) if defined?(@normalized_scheme)
-      remove_instance_variable(:@uri_string) if defined?(@uri_string)
-      remove_instance_variable(:@hash) if defined?(@hash)
+      remove_composite_values
 
       # Ensure we haven't created an invalid URI
       validate()
@@ -922,8 +921,7 @@ module Addressable
       remove_instance_variable(:@normalized_userinfo) if defined?(@normalized_userinfo)
       remove_instance_variable(:@authority) if defined?(@authority)
       remove_instance_variable(:@normalized_user) if defined?(@normalized_user)
-      remove_instance_variable(:@uri_string) if defined?(@uri_string)
-      remove_instance_variable(:@hash) if defined?(@hash)
+      remove_composite_values
 
       # Ensure we haven't created an invalid URI
       validate()
@@ -977,8 +975,7 @@ module Addressable
       remove_instance_variable(:@normalized_userinfo) if defined?(@normalized_userinfo)
       remove_instance_variable(:@authority) if defined?(@authority)
       remove_instance_variable(:@normalized_password) if defined?(@normalized_password)
-      remove_instance_variable(:@uri_string) if defined?(@uri_string)
-      remove_instance_variable(:@hash) if defined?(@hash)
+      remove_composite_values
 
       # Ensure we haven't created an invalid URI
       validate()
@@ -1042,8 +1039,7 @@ module Addressable
 
       # Reset dependent values
       remove_instance_variable(:@authority) if defined?(@authority)
-      remove_instance_variable(:@uri_string) if defined?(@uri_string)
-      remove_instance_variable(:@hash) if defined?(@hash)
+      remove_composite_values
 
       # Ensure we haven't created an invalid URI
       validate()
@@ -1099,8 +1095,7 @@ module Addressable
       # Reset dependent values
       remove_instance_variable(:@authority) if defined?(@authority)
       remove_instance_variable(:@normalized_host) if defined?(@normalized_host)
-      remove_instance_variable(:@uri_string) if defined?(@uri_string)
-      remove_instance_variable(:@hash) if defined?(@hash)
+      remove_composite_values
 
       # Ensure we haven't created an invalid URI
       validate()
@@ -1207,8 +1202,7 @@ module Addressable
       # Reset dependent values
       remove_instance_variable(:@userinfo) if defined?(@userinfo)
       remove_instance_variable(:@normalized_userinfo) if defined?(@normalized_userinfo)
-      remove_instance_variable(:@uri_string) if defined?(@uri_string)
-      remove_instance_variable(:@hash) if defined?(@hash)
+      remove_composite_values
 
       # Ensure we haven't created an invalid URI
       validate()
@@ -1289,8 +1283,7 @@ module Addressable
       # Reset dependent values
       remove_instance_variable(:@authority) if defined?(@authority)
       remove_instance_variable(:@normalized_port) if defined?(@normalized_port)
-      remove_instance_variable(:@uri_string) if defined?(@uri_string)
-      remove_instance_variable(:@hash) if defined?(@hash)
+      remove_composite_values
 
       # Ensure we haven't created an invalid URI
       validate()
@@ -1435,8 +1428,7 @@ module Addressable
 
       # Reset dependent values
       remove_instance_variable(:@normalized_path) if defined?(@normalized_path)
-      remove_instance_variable(:@uri_string) if defined?(@uri_string)
-      remove_instance_variable(:@hash) if defined?(@hash)
+      remove_composite_values
     end
 
     ##
@@ -1494,8 +1486,7 @@ module Addressable
 
       # Reset dependent values
       remove_instance_variable(:@normalized_query) if defined?(@normalized_query)
-      remove_instance_variable(:@uri_string) if defined?(@uri_string)
-      remove_instance_variable(:@hash) if defined?(@hash)
+      remove_composite_values
     end
 
     ##
@@ -1647,8 +1638,7 @@ module Addressable
       self.query = query_component
 
       # Reset dependent values
-      remove_instance_variable(:@uri_string) if defined?(@uri_string)
-      remove_instance_variable(:@hash) if defined?(@hash)
+      remove_composite_values
     end
 
     ##
@@ -1687,8 +1677,7 @@ module Addressable
 
       # Reset dependent values
       remove_instance_variable(:@normalized_fragment) if defined?(@normalized_fragment)
-      remove_instance_variable(:@uri_string) if defined?(@uri_string)
-      remove_instance_variable(:@hash) if defined?(@hash)
+      remove_composite_values
 
       # Ensure we haven't created an invalid URI
       validate()
@@ -2357,6 +2346,13 @@ module Addressable
       splitted = path.split(SLASH)
       splitted << EMPTY_STR if path.end_with? SLASH
       splitted
+    end
+
+    ##
+    # Resets composite values for the entire URI
+    def remove_composite_values
+      remove_instance_variable(:@uri_string) if defined?(@uri_string)
+      remove_instance_variable(:@hash) if defined?(@hash)
     end
   end
 end

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -720,9 +720,9 @@ module Addressable
           ).gsub("%20", "+")
         ]
       end
-      return (escaped_form_values.map do |(key, value)|
+      return escaped_form_values.map do |(key, value)|
         "#{key}=#{value}"
-      end).join("&")
+      end.join("&")
     end
 
     ##
@@ -839,7 +839,7 @@ module Addressable
     #
     # @return [String] The scheme component, normalized.
     def normalized_scheme
-      self.scheme && @normalized_scheme ||= (begin
+      self.scheme && @normalized_scheme ||= begin
         if self.scheme =~ /^\s*ssh\+svn\s*$/i
           "svn+ssh"
         else
@@ -848,7 +848,7 @@ module Addressable
             Addressable::URI::CharacterClasses::SCHEME
           )
         end
-      end)
+      end
     end
 
     ##
@@ -888,7 +888,7 @@ module Addressable
     #
     # @return [String] The user component, normalized.
     def normalized_user
-      self.user && @normalized_user ||= (begin
+      self.user && @normalized_user ||= begin
         if normalized_scheme =~ /https?/ && self.user.strip.empty? &&
             (!self.password || self.password.strip.empty?)
           nil
@@ -898,7 +898,7 @@ module Addressable
             Addressable::URI::CharacterClasses::UNRESERVED
           )
         end
-      end)
+      end
     end
 
     ##
@@ -940,7 +940,7 @@ module Addressable
     #
     # @return [String] The password component, normalized.
     def normalized_password
-      self.password && @normalized_password ||= (begin
+      self.password && @normalized_password ||= begin
         if self.normalized_scheme =~ /https?/ && self.password.strip.empty? &&
             (!self.user || self.user.strip.empty?)
           nil
@@ -950,7 +950,7 @@ module Addressable
             Addressable::URI::CharacterClasses::UNRESERVED
           )
         end
-      end)
+      end
     end
 
     ##
@@ -989,13 +989,13 @@ module Addressable
     def userinfo
       current_user = self.user
       current_password = self.password
-      (current_user || current_password) && @userinfo ||= (begin
+      (current_user || current_password) && @userinfo ||= begin
         if current_user && current_password
           "#{current_user}:#{current_password}"
         elsif current_user && !current_password
           "#{current_user}"
         end
-      end)
+      end
     end
 
     ##
@@ -1003,7 +1003,7 @@ module Addressable
     #
     # @return [String] The userinfo component, normalized.
     def normalized_userinfo
-      self.userinfo && @normalized_userinfo ||= (begin
+      self.userinfo && @normalized_userinfo ||= begin
         current_user = self.normalized_user
         current_password = self.normalized_password
         if !current_user && !current_password
@@ -1013,7 +1013,7 @@ module Addressable
         elsif current_user && !current_password
           "#{current_user}"
         end
-      end)
+      end
     end
 
     ##
@@ -1058,7 +1058,7 @@ module Addressable
     #
     # @return [String] The host component, normalized.
     def normalized_host
-      self.host && @normalized_host ||= (begin
+      self.host && @normalized_host ||= begin
         if !self.host.strip.empty?
           result = ::Addressable::IDNA.to_ascii(
             URI.unencode_component(self.host.strip.downcase)
@@ -1071,7 +1071,7 @@ module Addressable
         else
           EMPTY_STR
         end
-      end)
+      end
     end
 
     ##
@@ -1138,7 +1138,7 @@ module Addressable
     #
     # @return [String] The authority component.
     def authority
-      self.host && @authority ||= (begin
+      self.host && @authority ||= begin
         authority = ""
         if self.userinfo != nil
           authority << "#{self.userinfo}@"
@@ -1148,7 +1148,7 @@ module Addressable
           authority << ":#{self.port}"
         end
         authority
-      end)
+      end
     end
 
     ##
@@ -1156,7 +1156,7 @@ module Addressable
     #
     # @return [String] The authority component, normalized.
     def normalized_authority
-      self.authority && @normalized_authority ||= (begin
+      self.authority && @normalized_authority ||= begin
         authority = ""
         if self.normalized_userinfo != nil
           authority << "#{self.normalized_userinfo}@"
@@ -1166,7 +1166,7 @@ module Addressable
           authority << ":#{self.normalized_port}"
         end
         authority
-      end)
+      end
     end
 
     ##
@@ -1214,18 +1214,16 @@ module Addressable
     #
     # @return [String] The serialized origin.
     def origin
-      return (if self.scheme && self.authority
+      if self.scheme && self.authority
         if self.normalized_port
-          (
-            "#{self.normalized_scheme}://#{self.normalized_host}" +
-            ":#{self.normalized_port}"
-          )
+          "#{self.normalized_scheme}://#{self.normalized_host}" +
+          ":#{self.normalized_port}"
         else
           "#{self.normalized_scheme}://#{self.normalized_host}"
         end
       else
         "null"
-      end)
+      end
     end
 
     # Returns an array of known ip-based schemes. These schemes typically
@@ -1323,12 +1321,12 @@ module Addressable
     #
     # @return [String] The components that identify a site.
     def site
-      (self.scheme || self.authority) && @site ||= (begin
+      (self.scheme || self.authority) && @site ||= begin
         site_string = ""
         site_string << "#{self.scheme}:" if self.scheme != nil
         site_string << "//#{self.authority}" if self.authority != nil
         site_string
-      end)
+      end
     end
 
     ##
@@ -1341,7 +1339,7 @@ module Addressable
     #
     # @return [String] The normalized components that identify a site.
     def normalized_site
-      self.site && @normalized_site ||= (begin
+      self.site && @normalized_site ||= begin
         site_string = ""
         if self.normalized_scheme != nil
           site_string << "#{self.normalized_scheme}:"
@@ -1350,7 +1348,7 @@ module Addressable
           site_string << "//#{self.normalized_authority}"
         end
         site_string
-      end)
+      end
     end
 
     ##
@@ -1389,7 +1387,7 @@ module Addressable
     #
     # @return [String] The path component, normalized.
     def normalized_path
-      @normalized_path ||= (begin
+      @normalized_path ||= begin
         path = self.path.to_s
         if self.scheme == nil && path =~ NORMPATH
           # Relative paths with colons in the first segment are ambiguous.
@@ -1397,12 +1395,12 @@ module Addressable
         end
         # String#split(delimeter, -1) uses the more strict splitting behavior
         # found by default in Python.
-        result = (path.strip.split(SLASH, -1).map do |segment|
+        result = path.strip.split(SLASH, -1).map do |segment|
           Addressable::URI.normalize_component(
             segment,
             Addressable::URI::CharacterClasses::PCHAR
           )
-        end).join(SLASH)
+        end.join(SLASH)
 
         result = URI.normalize_path(result)
         if result.empty? &&
@@ -1410,7 +1408,7 @@ module Addressable
           result = SLASH
         end
         result
-      end)
+      end
     end
 
     ##
@@ -1468,9 +1466,9 @@ module Addressable
       modified_query_class.sub!("\\&", "").sub!("\\;", "")
       pairs = (self.query || "").split("&", -1)
       pairs.sort! if flags.include?(:sorted)
-      component = (pairs.map do |pair|
+      component = pairs.map do |pair|
         Addressable::URI.normalize_component(pair, modified_query_class, "+")
-      end).join("&")
+      end.join("&")
       component == "" ? nil : component
     end
 
@@ -1515,9 +1513,9 @@ module Addressable
         raise ArgumentError, "Invalid return type. Must be Hash or Array."
       end
       return nil if self.query == nil
-      split_query = (self.query.split("&").map do |pair|
+      split_query = self.query.split("&").map do |pair|
         pair.split("=", 2) if pair && !pair.empty?
-      end).compact
+      end.compact
       return split_query.inject(empty_accumulator.dup) do |accu, pair|
         # I'd rather use key/value identifiers instead of array lookups,
         # but in this case I really want to maintain the exact pair structure,
@@ -2098,7 +2096,7 @@ module Addressable
     #
     # @return [Integer] A hash of the URI.
     def hash
-      return @hash ||= (self.to_s.hash * -1)
+      return @hash ||= self.to_s.hash * -1
     end
 
     ##
@@ -2181,7 +2179,7 @@ module Addressable
         raise InvalidURIError,
           "Cannot assemble URI string with ambiguous path: '#{self.path}'"
       end
-      @uri_string ||= (begin
+      @uri_string ||= begin
         uri_string = ""
         uri_string << "#{self.scheme}:" if self.scheme != nil
         uri_string << "//#{self.authority}" if self.authority != nil
@@ -2192,7 +2190,7 @@ module Addressable
           uri_string.force_encoding(Encoding::UTF_8)
         end
         uri_string
-      end)
+      end
     end
 
     ##

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -831,7 +831,7 @@ module Addressable
     #
     # @return [String] The scheme component.
     def scheme
-      return instance_variable_defined?(:@scheme) ? @scheme : nil
+      return defined?(@scheme) ? @scheme : nil
     end
 
     ##
@@ -881,7 +881,7 @@ module Addressable
     #
     # @return [String] The user component.
     def user
-      return instance_variable_defined?(:@user) ? @user : nil
+      return defined?(@user) ? @user : nil
     end
 
     ##
@@ -934,7 +934,7 @@ module Addressable
     #
     # @return [String] The password component.
     def password
-      return instance_variable_defined?(:@password) ? @password : nil
+      return defined?(@password) ? @password : nil
     end
 
     ##
@@ -1054,7 +1054,7 @@ module Addressable
     #
     # @return [String] The host component.
     def host
-      return instance_variable_defined?(:@host) ? @host : nil
+      return defined?(@host) ? @host : nil
     end
 
     ##
@@ -1255,7 +1255,7 @@ module Addressable
     #
     # @return [Integer] The port component.
     def port
-      return instance_variable_defined?(:@port) ? @port : nil
+      return defined?(@port) ? @port : nil
     end
 
     ##
@@ -1387,7 +1387,7 @@ module Addressable
     #
     # @return [String] The path component.
     def path
-      return instance_variable_defined?(:@path) ? @path : EMPTY_STR
+      return defined?(@path) ? @path : EMPTY_STR
     end
 
     NORMPATH = /^(?!\/)[^\/:]*:.*$/
@@ -1463,7 +1463,7 @@ module Addressable
     #
     # @return [String] The query component.
     def query
-      return instance_variable_defined?(:@query) ? @query : nil
+      return defined?(@query) ? @query : nil
     end
 
     ##
@@ -1656,7 +1656,7 @@ module Addressable
     #
     # @return [String] The fragment component.
     def fragment
-      return instance_variable_defined?(:@fragment) ? @fragment : nil
+      return defined?(@fragment) ? @fragment : nil
     end
 
     ##
@@ -1665,7 +1665,7 @@ module Addressable
     # @return [String] The fragment component, normalized.
     def normalized_fragment
       return unless self.fragment
-      return @normalized_fragment if instance_variable_defined?(:@normalized_fragment)
+      return @normalized_fragment if defined?(@normalized_fragment)
       @normalized_fragment ||= begin
         component = Addressable::URI.normalize_component(
           self.fragment,
@@ -1686,9 +1686,9 @@ module Addressable
       @fragment = new_fragment ? new_fragment.to_str : nil
 
       # Reset dependant values
-      remove_instance_variable(:@normalized_fragment) if instance_variable_defined?(:@normalized_fragment)
-      remove_instance_variable(:@uri_string) if instance_variable_defined?(:@uri_string)
-      remove_instance_variable(:@hash) if instance_variable_defined?(:@hash)
+      remove_instance_variable(:@normalized_fragment) if defined?(@normalized_fragment)
+      remove_instance_variable(:@uri_string) if defined?(@uri_string)
+      remove_instance_variable(:@hash) if defined?(@hash)
 
       # Ensure we haven't created an invalid URI
       validate()

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1264,10 +1264,14 @@ module Addressable
     #
     # @return [Integer] The port component, normalized.
     def normalized_port
-      if URI.port_mapping[self.normalized_scheme] == self.port
-        nil
-      else
-        self.port
+      return nil unless self.port
+      return @normalized_port if defined?(@normalized_port)
+      @normalized_port ||= begin
+        if URI.port_mapping[self.normalized_scheme] == self.port
+          nil
+        else
+          self.port
+        end
       end
     end
 

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -867,10 +867,10 @@ module Addressable
       @scheme = new_scheme
       @scheme = nil if @scheme.to_s.strip.empty?
 
-      # Reset dependant values
-      @normalized_scheme = nil
-      @uri_string = nil
-      @hash = nil
+      # Reset dependent values
+      remove_instance_variable(:@normalized_scheme) if defined?(@normalized_scheme)
+      remove_instance_variable(:@uri_string) if defined?(@uri_string)
+      remove_instance_variable(:@hash) if defined?(@hash)
 
       # Ensure we haven't created an invalid URI
       validate()
@@ -917,13 +917,13 @@ module Addressable
         @user = EMPTY_STR if @user.nil?
       end
 
-      # Reset dependant values
-      @userinfo = nil
-      @normalized_userinfo = nil
-      @authority = nil
-      @normalized_user = nil
-      @uri_string = nil
-      @hash = nil
+      # Reset dependent values
+      remove_instance_variable(:@userinfo) if defined?(@userinfo)
+      remove_instance_variable(:@normalized_userinfo) if defined?(@normalized_userinfo)
+      remove_instance_variable(:@authority) if defined?(@authority)
+      remove_instance_variable(:@normalized_user) if defined?(@normalized_user)
+      remove_instance_variable(:@uri_string) if defined?(@uri_string)
+      remove_instance_variable(:@hash) if defined?(@hash)
 
       # Ensure we haven't created an invalid URI
       validate()
@@ -972,13 +972,13 @@ module Addressable
         @user = EMPTY_STR if @user.nil?
       end
 
-      # Reset dependant values
-      @userinfo = nil
-      @normalized_userinfo = nil
-      @authority = nil
-      @normalized_password = nil
-      @uri_string = nil
-      @hash = nil
+      # Reset dependent values
+      remove_instance_variable(:@userinfo) if defined?(@userinfo)
+      remove_instance_variable(:@normalized_userinfo) if defined?(@normalized_userinfo)
+      remove_instance_variable(:@authority) if defined?(@authority)
+      remove_instance_variable(:@normalized_password) if defined?(@normalized_password)
+      remove_instance_variable(:@uri_string) if defined?(@uri_string)
+      remove_instance_variable(:@hash) if defined?(@hash)
 
       # Ensure we haven't created an invalid URI
       validate()
@@ -1040,10 +1040,10 @@ module Addressable
       self.password = new_password
       self.user = new_user
 
-      # Reset dependant values
-      @authority = nil
-      @uri_string = nil
-      @hash = nil
+      # Reset dependent values
+      remove_instance_variable(:@authority) if defined?(@authority)
+      remove_instance_variable(:@uri_string) if defined?(@uri_string)
+      remove_instance_variable(:@hash) if defined?(@hash)
 
       # Ensure we haven't created an invalid URI
       validate()
@@ -1096,11 +1096,11 @@ module Addressable
         raise InvalidURIError, "Invalid character in host: '#{@host.to_s}'"
       end
 
-      # Reset dependant values
-      @authority = nil
-      @normalized_host = nil
-      @uri_string = nil
-      @hash = nil
+      # Reset dependent values
+      remove_instance_variable(:@authority) if defined?(@authority)
+      remove_instance_variable(:@normalized_host) if defined?(@normalized_host)
+      remove_instance_variable(:@uri_string) if defined?(@uri_string)
+      remove_instance_variable(:@hash) if defined?(@hash)
 
       # Ensure we haven't created an invalid URI
       validate()
@@ -1204,11 +1204,11 @@ module Addressable
       self.host = defined?(new_host) ? new_host : nil
       self.port = defined?(new_port) ? new_port : nil
 
-      # Reset dependant values
-      @userinfo = nil
-      @normalized_userinfo = nil
-      @uri_string = nil
-      @hash = nil
+      # Reset dependent values
+      remove_instance_variable(:@userinfo) if defined?(@userinfo)
+      remove_instance_variable(:@normalized_userinfo) if defined?(@normalized_userinfo)
+      remove_instance_variable(:@uri_string) if defined?(@uri_string)
+      remove_instance_variable(:@hash) if defined?(@hash)
 
       # Ensure we haven't created an invalid URI
       validate()
@@ -1286,11 +1286,11 @@ module Addressable
       @port = new_port.to_s.to_i
       @port = nil if @port == 0
 
-      # Reset dependant values
-      @authority = nil
-      @normalized_port = nil
-      @uri_string = nil
-      @hash = nil
+      # Reset dependent values
+      remove_instance_variable(:@authority) if defined?(@authority)
+      remove_instance_variable(:@normalized_port) if defined?(@normalized_port)
+      remove_instance_variable(:@uri_string) if defined?(@uri_string)
+      remove_instance_variable(:@hash) if defined?(@hash)
 
       # Ensure we haven't created an invalid URI
       validate()
@@ -1433,10 +1433,10 @@ module Addressable
         @path = "/#{@path}"
       end
 
-      # Reset dependant values
-      @normalized_path = nil
-      @uri_string = nil
-      @hash = nil
+      # Reset dependent values
+      remove_instance_variable(:@normalized_path) if defined?(@normalized_path)
+      remove_instance_variable(:@uri_string) if defined?(@uri_string)
+      remove_instance_variable(:@hash) if defined?(@hash)
     end
 
     ##
@@ -1492,10 +1492,10 @@ module Addressable
       end
       @query = new_query ? new_query.to_str : nil
 
-      # Reset dependant values
-      @normalized_query = nil
-      @uri_string = nil
-      @hash = nil
+      # Reset dependent values
+      remove_instance_variable(:@normalized_query) if defined?(@normalized_query)
+      remove_instance_variable(:@uri_string) if defined?(@uri_string)
+      remove_instance_variable(:@hash) if defined?(@hash)
     end
 
     ##
@@ -1646,9 +1646,9 @@ module Addressable
       self.path = path_component
       self.query = query_component
 
-      # Reset dependant values
-      @uri_string = nil
-      @hash = nil
+      # Reset dependent values
+      remove_instance_variable(:@uri_string) if defined?(@uri_string)
+      remove_instance_variable(:@hash) if defined?(@hash)
     end
 
     ##
@@ -1685,7 +1685,7 @@ module Addressable
       end
       @fragment = new_fragment ? new_fragment.to_str : nil
 
-      # Reset dependant values
+      # Reset dependent values
       remove_instance_variable(:@normalized_fragment) if defined?(@normalized_fragment)
       remove_instance_variable(:@uri_string) if defined?(@uri_string)
       remove_instance_variable(:@hash) if defined?(@hash)
@@ -2329,9 +2329,9 @@ module Addressable
     #
     # @return [Addressable::URI] <code>self</code>.
     def replace_self(uri)
-      # Reset dependant values
+      # Reset dependent values
       instance_variables.each do |var|
-        instance_variable_set(var, nil)
+        remove_instance_variable(var) if instance_variable_defined?(var)
       end
 
       @scheme = uri.scheme

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1475,15 +1475,19 @@ module Addressable
     #
     # @return [String] The query component, normalized.
     def normalized_query(*flags)
-      modified_query_class = Addressable::URI::CharacterClasses::QUERY.dup
-      # Make sure possible key-value pair delimiters are escaped.
-      modified_query_class.sub!("\\&", "").sub!("\\;", "")
-      pairs = (self.query || "").split("&", -1)
-      pairs.sort! if flags.include?(:sorted)
-      component = pairs.map do |pair|
-        Addressable::URI.normalize_component(pair, modified_query_class, "+")
-      end.join("&")
-      component == "" ? nil : component
+      return nil unless self.query
+      return @normalized_query if defined?(@normalized_query)
+      @normalized_query ||= begin
+        modified_query_class = Addressable::URI::CharacterClasses::QUERY.dup
+        # Make sure possible key-value pair delimiters are escaped.
+        modified_query_class.sub!("\\&", "").sub!("\\;", "")
+        pairs = (self.query || "").split("&", -1)
+        pairs.sort! if flags.include?(:sorted)
+        component = pairs.map do |pair|
+          Addressable::URI.normalize_component(pair, modified_query_class, "+")
+        end.join("&")
+        component == "" ? nil : component
+      end
     end
 
     ##


### PR DESCRIPTION
In the case where a fragment is present but empty (e.g. "http://example.com#"), the `normalized_fragment` method returns `nil`, so it can't be memoized with `||=`. This [patch](https://github.com/sferik/addressable/commit/67e36a4c7f406b874281037b3454d2cfd19ddc44) fixes this problem, so the `@normalized_fragment` instance variable is only ever assigned once, even when the method returns `nil`. This was causing an issue with frozen Addressable::URI (see https://github.com/sferik/t/issues/197).

I hope you’ll find a moment to release this fix during your adventures in Tanzania.

Cheers! :beers: