### PR TITLE
Deprecation fix: File.exists? => File.exist

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -262,7 +262,7 @@ module Addressable
           "/#{$1.downcase}:/"
         end
         uri.path.gsub!(/\\/, SLASH)
-        if File.exists?(uri.path) &&
+        if File.exist?(uri.path) &&
             File.stat(uri.path).directory?
           uri.path.gsub!(/\/$/, EMPTY_STR)
           uri.path = uri.path + '/'

--- a/spec/addressable/template_spec.rb
+++ b/spec/addressable/template_spec.rb
@@ -749,7 +749,7 @@ describe Addressable::Template do
     }
     context "first uri with ExampleTwoProcessor" do
       subject {
-        match = Addressable::Template.new(
+        Addressable::Template.new(
           "http://example.com/search/{query}/"
         ).match(uri, ExampleTwoProcessor)
       }
@@ -759,7 +759,7 @@ describe Addressable::Template do
 
     context "second uri with ExampleTwoProcessor" do
       subject {
-        match = Addressable::Template.new(
+        Addressable::Template.new(
           "http://example.com/{first}/{+second}/"
         ).match(uri2, ExampleTwoProcessor)
       }
@@ -769,7 +769,7 @@ describe Addressable::Template do
 
     context "second uri with DumbProcessor" do
       subject {
-        match = Addressable::Template.new(
+        Addressable::Template.new(
           "http://example.com/{first}/{+second}/"
         ).match(uri2, DumbProcessor)
       }
@@ -779,7 +779,7 @@ describe Addressable::Template do
 
     context "second uri" do
       subject {
-        match = Addressable::Template.new(
+        Addressable::Template.new(
           "http://example.com/{first}{/second*}/"
         ).match(uri2)
       }
@@ -788,7 +788,7 @@ describe Addressable::Template do
     end
     context "third uri" do
       subject {
-        match = Addressable::Template.new(
+        Addressable::Template.new(
           "http://example.com/{;hash*,first}"
         ).match(uri3)
       }
@@ -801,7 +801,7 @@ describe Addressable::Template do
     # Semantically, a separate key is more likely, but both are possible.
     context "fourth uri" do
       subject {
-        match = Addressable::Template.new(
+        Addressable::Template.new(
           "http://example.com/{?hash*,first}"
         ).match(uri4)
       }
@@ -811,7 +811,7 @@ describe Addressable::Template do
     end
     context "fifth uri" do
       subject {
-        match = Addressable::Template.new(
+        Addressable::Template.new(
           "http://example.com/{path}{?hash*,first}"
         ).match(uri5)
       }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,3 +6,7 @@ begin
 rescue LoadError
   warn "warning: coveralls gem not found; skipping Coveralls"
 end
+
+RSpec.configure do |config|
+  config.warnings = true
+end


### PR DESCRIPTION
Address deprecation warning:

     ...ruby/2.1.3/gems/addressable-2.3.6/lib/addressable/uri.rb:265: warning: File.exists? is a deprecated name, use File.exist? instead