### PR TITLE
Let query_values return something meaningful

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1515,7 +1515,7 @@ module Addressable
       if return_type != Hash && return_type != Array
         raise ArgumentError, "Invalid return type. Must be Hash or Array."
       end
-      return nil if self.query == nil
+      return return_type.new if query.nil?
       split_query = (self.query.split("&").map do |pair|
         pair.split("=", 2) if pair && !pair.empty?
       end).compact

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -194,6 +194,14 @@ describe Addressable::URI, "when created from nil components" do
     expect(@uri.default_port).to eq(nil)
   end
 
+  it "should have an empty query_value" do
+    expect(@uri.query_values).to eq({})
+  end
+
+  it "should have an emtpy query_values Array when requesting an array" do
+    expect(@uri.query_values(Array)).to eq([])
+  end
+
   it "should be empty" do
     expect(@uri).to be_empty
   end
@@ -1560,7 +1568,7 @@ describe Addressable::URI, "when parsed from " +
 
   it "should have no query string" do
     expect(@uri.query).to eq(nil)
-    expect(@uri.query_values).to eq(nil)
+    expect(@uri.query_values).to eq({})
   end
 
   it "should have a request URI of '/'" do


### PR DESCRIPTION
`query_values` now returns an empty version of its `return_type` instead of nil when there is no query.

So the following is `true:
`ruby
Addressable::URI.parse('http://example.com').query_values == {}
```
