### PR TITLE
Addressable templates are now compatible with a minimally-patched version of rack-mount.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ group :test, :development do
   gem 'coveralls', :require => false, :platforms => [
     :ruby_19, :ruby_20, :ruby_21, :rbx, :jruby
   ]
+  # Used to test compatibility.
+  gem 'rack-mount', git: 'https://github.com/sporkmonger/rack-mount.git'
 end
 
 gem 'idn', :platform => :mri_18

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -647,6 +647,15 @@ module Addressable
       self.to_regexp.named_captures
     end
 
+    ##
+    # Generates a route result for a given set of parameters.
+    # Should only be used by rack-routes.
+    #
+    # @api private
+    def generate(params, recall={}, options={})
+      expand(params, options[:processor])
+    end
+
   private
     def ordered_variable_defaults
       @ordered_variable_defaults ||= (

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -640,7 +640,7 @@ module Addressable
     ##
     # Returns the named captures of the coerced `Regexp`.
     #
-    # @return [String] The named captures of the `Regexp` given by {#to_regexp}.
+    # @return [Hash] The named captures of the `Regexp` given by {#to_regexp}.
     #
     # @api private
     def named_captures

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -683,7 +683,7 @@ module Addressable
 
   private
     def ordered_variable_defaults
-      @ordered_variable_defaults ||= (
+      @ordered_variable_defaults ||= begin
         expansions, _ = parse_template_pattern(pattern)
         expansions.map do |capture|
           _, _, varlist = *capture.match(EXPRESSION)
@@ -691,7 +691,7 @@ module Addressable
             varspec[VARSPEC, 1]
           end
         end.flatten
-      )
+      end
     end
 
 

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -651,6 +651,10 @@ module Addressable
     # Generates a route result for a given set of parameters.
     # Should only be used by rack-mount.
     #
+    # @param params [Hash] The set of parameters used to expand the template.
+    # @param recall [Hash] Default parameters used to expand the template.
+    # @param options [Hash] Either a `:processor` or a `:parameterize` block.
+    #
     # @api private
     def generate(params={}, recall={}, options={})
       merged = recall.merge(params)

--- a/spec/addressable/rack_mount_compat_spec.rb
+++ b/spec/addressable/rack_mount_compat_spec.rb
@@ -1,0 +1,101 @@
+# coding: utf-8
+# Copyright (C) 2006-2015 Bob Aman
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+
+require "spec_helper"
+
+require "addressable/uri"
+require "addressable/template"
+require "rack/mount"
+
+describe Rack::Mount do
+  let(:app_one) do
+    proc { |env| [200, {'Content-Type' => 'text/plain'}, 'Route 1'] }
+  end
+  let(:app_two) do
+    proc { |env| [200, {'Content-Type' => 'text/plain'}, 'Route 2'] }
+  end
+  let(:app_three) do
+    proc { |env| [200, {'Content-Type' => 'text/plain'}, 'Route 3'] }
+  end
+  let(:routes) do
+    set = Rack::Mount::RouteSet.new do |set|
+      set.add_route(app_one, {
+        :request_method => 'GET',
+        :path_info => Addressable::Template.new('/one/{id}/')
+      }, {:id => 'unidentified'}, :one)
+      set.add_route(app_two, {
+        :request_method => 'GET',
+        :path_info => Addressable::Template.new('/two/{id}/')
+      }, {:id => 'unidentified'}, :two)
+      set.add_route(app_three, {
+        :request_method => 'GET',
+        :path_info => Addressable::Template.new('/three/{id}/').to_regexp
+      }, {:id => 'unidentified'}, :three)
+    end
+    set.rehash
+    set
+  end
+
+  it "should generate from routes with Addressable::Template" do
+    path, _ = routes.generate(:path_info, :one, {:id => '123'})
+    expect(path).to eq '/one/123/'
+  end
+
+  it "should generate from routes with Addressable::Template using defaults" do
+    path, _ = routes.generate(:path_info, :one, {})
+    expect(path).to eq '/one/unidentified/'
+  end
+
+  it "should recognize routes with Addressable::Template" do
+    request = Rack::Request.new(
+      'REQUEST_METHOD' => 'GET',
+      'PATH_INFO' => '/one/123/'
+    )
+    route, matches, params = routes.recognize(request)
+    expect(route).not_to be_nil
+    expect(route.app).to eq app_one
+  end
+
+  it "should generate from routes with Addressable::Template" do
+    path, _ = routes.generate(:path_info, :two, {:id => '654'})
+    expect(path).to eq '/two/654/'
+  end
+
+  it "should generate from routes with Addressable::Template using defaults" do
+    path, _ = routes.generate(:path_info, :two, {})
+    expect(path).to eq '/two/unidentified/'
+  end
+
+  it "should recognize routes with Addressable::Template" do
+    request = Rack::Request.new(
+      'REQUEST_METHOD' => 'GET',
+      'PATH_INFO' => '/two/654/'
+    )
+    route, matches, params = routes.recognize(request)
+    expect(route).not_to be_nil
+    expect(route.app).to eq app_two
+  end
+
+  it "should recognize routes with derived Regexp" do
+    request = Rack::Request.new(
+      'REQUEST_METHOD' => 'GET',
+      'PATH_INFO' => '/three/789/'
+    )
+    route, matches, params = routes.recognize(request)
+    expect(route).not_to be_nil
+    expect(route.app).to eq app_three
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,12 +4,14 @@ begin
   require 'coveralls'
   Coveralls.wear! do
     add_filter "spec/"
+    add_filter "vendor/"
   end
 rescue LoadError
   warn "warning: coveralls gem not found; skipping Coveralls"
   require 'simplecov'
   SimpleCov.start do
     add_filter "spec/"
+    add_filter "vendor/"
   end
 end
 


### PR DESCRIPTION
Requires a patched version of [rack-mount](https://github.com/sporkmonger/rack-mount) until the patch is merged and a new release gets cut. However, rack-mount does not appear to be regularly maintained, so the patched version may be required indefinitely.