### PR TITLE
Avoid producing invalid urls for partial form-style query expansion

### DIFF
--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -725,13 +725,13 @@ module Addressable
 
       if '?' == operator
         # partial expansion of form style query variables sometimes requires a
-        # slight reordering of the variables to produce a value url.
+        # slight reordering of the variables to produce a valid url.
         first_to_expand = vars.find { |varspec|
           _, name, _ =  *varspec.match(VARSPEC)
           mapping.key? name
         }
 
-        vars = [first_to_expand] + vars.reject {|varspec| varspec == first_to_expand}
+        vars = [first_to_expand] + vars.reject {|varspec| varspec == first_to_expand}  if first_to_expand
       end
 
       vars

--- a/spec/addressable/template_spec.rb
+++ b/spec/addressable/template_spec.rb
@@ -698,6 +698,13 @@ describe "Expansion" do
       ]
     }
   end
+  context "non-string key in match data" do
+    subject {Addressable::Template.new("http://example.com/{one}")}
+
+    it "raises TypeError" do
+      expect { subject.expand(Object.new => "1") }.to raise_error TypeError
+    end
+  end
 end
 
 class ExampleTwoProcessor
@@ -931,13 +938,23 @@ describe Addressable::Template do
         )
       end
     end
+    context "partial_expand form style query with missing param at beginning" do
+      subject {
+        Addressable::Template.new("http://example.com/{?one,two}/")
+      }
+      it "builds a new pattern" do
+        expect(subject.partial_expand(:two => "2").pattern).to eq(
+          "http://example.com/?two=2{&one}/"
+        )
+      end
+    end
     context "partial_expand with query string" do
       subject {
         Addressable::Template.new("http://example.com/{?two,one}/")
       }
       it "builds a new pattern" do
         expect(subject.partial_expand(:one => "1").pattern).to eq(
-          "http://example.com/{?two}&one=1/"
+          "http://example.com/?one=1{&two}/"
         )
       end
     end
@@ -979,7 +996,7 @@ describe Addressable::Template do
       }
       it "builds a new pattern" do
         expect(subject.partial_expand("one" => "1").pattern).to eq(
-          "http://example.com/{?two}&one=1/"
+          "http://example.com/?one=1{&two}/"
         )
       end
     end
@@ -1028,7 +1045,7 @@ describe Addressable::Template do
       }
       it "builds a new pattern" do
         expect(subject.partial_expand("one" => "1").pattern).to eq(
-          "http://example.com/{?two}&one=1/"
+          "http://example.com/?one=1{&two}/"
         )
       end
     end


### PR DESCRIPTION
When `http://example.com/{?a,b}` is partially expanded with `b: 2` the result must be `http://example.com/?b=2{&a}`. That way if the final expansion is done w/ `a` undefined the resulting URL will be valid.

If the form-style query vars are not reordered and final expansion is done w/ `a` undefined the result is
`http://example.com/&b=2` which is clearly malformed.