### PR TITLE
Newline in hostname

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1098,7 +1098,7 @@ module Addressable
 
       unreserved = CharacterClasses::UNRESERVED
       sub_delims = CharacterClasses::SUB_DELIMS
-      if @host != nil && (@host =~ /[<>{}\/\?\#\@"\n]/ ||
+      if @host != nil && (@host =~ /[<>{}\/\?\#\@"\r\n]/ ||
           (@host[/^\[(.*)\]$/, 1] != nil && @host[/^\[(.*)\]$/, 1] !~
           Regexp.new("^[#{unreserved}#{sub_delims}:]*$")))
         raise InvalidURIError, "Invalid character in host: '#{@host.to_s}'"

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1098,7 +1098,7 @@ module Addressable
 
       unreserved = CharacterClasses::UNRESERVED
       sub_delims = CharacterClasses::SUB_DELIMS
-      if @host != nil && (@host =~ /[<>{}\/\?\#\@"\r\n]/ ||
+      if @host != nil && (@host =~ /[<>{}\/\?\#\@"[[:space:]]]/ ||
           (@host[/^\[(.*)\]$/, 1] != nil && @host[/^\[(.*)\]$/, 1] !~
           Regexp.new("^[#{unreserved}#{sub_delims}:]*$")))
         raise InvalidURIError, "Invalid character in host: '#{@host.to_s}'"

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -44,6 +44,7 @@ module Addressable
       UNRESERVED = ALPHA + DIGIT + "\\-\\.\\_\\~"
       PCHAR = UNRESERVED + SUB_DELIMS + "\\:\\@"
       SCHEME = ALPHA + DIGIT + "\\-\\+\\."
+      HOST = ALPHA + DIGIT + "\\-\\.\\[\\:\\]"
       AUTHORITY = PCHAR
       PATH = PCHAR + "\\/"
       QUERY = PCHAR + "\\/\\?"
@@ -1075,6 +1076,9 @@ module Addressable
             # Single trailing dots are unnecessary.
             result = result[0...-1]
           end
+          result = Addressable::URI.normalize_component(
+            result,
+            CharacterClasses::HOST)
           result
         else
           EMPTY_STR
@@ -1094,7 +1098,7 @@ module Addressable
 
       unreserved = CharacterClasses::UNRESERVED
       sub_delims = CharacterClasses::SUB_DELIMS
-      if @host != nil && (@host =~ /[<>{}\/\?\#\@"]/ ||
+      if @host != nil && (@host =~ /[<>{}\/\?\#\@"\n]/ ||
           (@host[/^\[(.*)\]$/, 1] != nil && @host[/^\[(.*)\]$/, 1] !~
           Regexp.new("^[#{unreserved}#{sub_delims}:]*$")))
         raise InvalidURIError, "Invalid character in host: '#{@host.to_s}'"

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -168,6 +168,40 @@ describe Addressable::URI, "quote handling" do
   end
 end
 
+describe Addressable::URI, "newline normalization" do
+  it "should not unescape newline in scheme" do
+    uri = Addressable::URI.parse("ht%0atp://localhost/").normalize
+    expect(uri.to_s).to eq("ht%0Atp://localhost/")
+  end
+
+  it "should not unescape newline in path" do
+    uri = Addressable::URI.parse("http://localhost/%0a").normalize
+    expect(uri.to_s).to eq("http://localhost/%0A")
+  end
+
+  it "should not unescape newline in hostname" do
+    uri = Addressable::URI.parse("http://local%0ahost/").normalize
+    expect(uri.to_s).to eq("http://local%0Ahost/")
+  end
+
+  it "should not unescape newline in username" do
+    uri = Addressable::URI.parse("http://foo%0abar@localhost/").normalize
+    expect(uri.to_s).to eq("http://foo%0Abar@localhost/")
+  end
+
+  it "should not unescape newline in username" do
+    uri = Addressable::URI.parse("http://example:foo%0abar@localhost/").normalize
+    expect(uri.to_s).to eq("http://example:foo%0Abar@localhost/")
+  end
+
+  it "should not accept newline in hostname" do
+    uri = Addressable::URI.parse("http://localhost/")
+    expect(lambda do
+      uri.host = "local\nhost"
+    end).to raise_error(Addressable::URI::InvalidURIError)
+  end
+end
+
 describe Addressable::URI, "when created with ambiguous path" do
   it "should raise an error" do
     expect(lambda do


### PR DESCRIPTION
When %0a is present in the hostname and `.normalize` is called on the URI object, the newline is unescaped, which is not desirable.

```
irb(main):001:0> require 'addressable/uri'
 => true
irb(main):002:0> url = Addressable::URI.parse('http://abc%0adef/')
 => #<Addressable::URI:0x3ffebdcbde2c URI:http://abc%0adef/>
irb(main):003:0> url
 => #<Addressable::URI:0x3ffebdcbde2c URI:http://abc%0adef/>
irb(main):004:0> url.to_s
 => "http://abc%0adef/"
irb(main):005:0> url.normalize.to_s
 => "http://abc\ndef/"
```

ping @sporkmonger