### PR TITLE
Raise StandardError instead of Exception

### DIFF
--- a/lib/addressable/idna/pure.rb
+++ b/lib/addressable/idna/pure.rb
@@ -487,7 +487,7 @@ module Addressable
       outlen.times do |j|
         c = output[j]
         unless c >= 0 && c <= 127
-          raise Exception, "Invalid output char."
+          raise StandardError, "Invalid output char."
         end
         unless PUNYCODE_PRINT_ASCII[c]
           raise PunycodeBadInput, "Input is invalid."


### PR DESCRIPTION
Don't raise Exception classes, use StandardError instead.

https://robots.thoughtbot.com/rescue-standarderror-not-exception
https://www.relishapp.com/womply/ruby-style-guide/docs/exceptions
http://stackoverflow.com/questions/10048173/why-is-it-bad-style-to-rescue-exception-e-in-ruby/10048406#10048406
