### PR TITLE
Adding section in readme to explain how to use with Bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,12 @@ $ sudo apt-get install idn # Debian/Ubuntu
 $ brew install libidn # OS X
 $ gem install idn-ruby
 ```
+
+# Bundler
+
+```ruby
+gem 'addressable', require: 'addressable/uri'
+gem 'addressable', require: 'addressable/template'
+```
+
+Because this gem is split into two different modules you need to explicitly tell Bundler which modules you want by using the require statements shown above. Both lines are not required, if you are not going to use the templating features of the gem you can simply not include that line.


### PR DESCRIPTION
I had a little bit of difficulty setting this bundle up in my Gemfile at first because I didn't realize you had split the gem into 2 separate modules that you have to explicitly include. I figured it out after a while but hopefully by putting this info in the readme it will alleviate some confusion