### PR TITLE
Remove explicit query param sorting

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1638,9 +1638,6 @@ module Addressable
           key = key.to_s if key.kind_of?(Symbol)
           [key, value]
         end
-        # Useful default for OAuth and caching.
-        # Only to be used for non-Array inputs. Arrays should preserve order.
-        new_query_values.sort!
       end
 
       # new_query_values have form [['key1', 'value1'], ['key2', 'value2']]

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -6100,9 +6100,9 @@ describe Addressable::URI, "when assigning query values" do
     expect(@uri.query).to eq(nil)
   end
 
-  it "should correctly sort {'ab' => 'c', :ab => 'a', :a => 'x'}" do
+  it "should maintain original ordering: {'ab' => 'c', :ab => 'a', :a => 'x'}" do
     @uri.query_values = {'ab' => 'c', :ab => 'a', :a => 'x'}
-    expect(@uri.query).to eq("a=x&ab=a&ab=c")
+    expect(@uri.query).to eq("ab=c&ab=a&a=x")
   end
 
   it "should correctly assign " +

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -6100,7 +6100,7 @@ describe Addressable::URI, "when assigning query values" do
     expect(@uri.query).to eq(nil)
   end
 
-  it "should maintain original ordering: {'ab' => 'c', :ab => 'a', :a => 'x'}" do
+  it "maintains original ordering: {'ab' => 'c', :ab => 'a', :a => 'x'}" do
     @uri.query_values = {'ab' => 'c', :ab => 'a', :a => 'x'}
     expect(@uri.query).to eq("ab=c&ab=a&a=x")
   end


### PR DESCRIPTION
@sporkmonger 

This fixed #192 and removes the sorting for query values.

Since this feature was used to support the now unsupported
  1.8.x, it can be removed.