### PR TITLE
Remove explicit query param sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Addressable 3.0
+- removed default query param sorting
+
 # Addressable 2.3.2
 - added Addressable::URI#default_port method
 - fixed issue with Marshalling Unicode data on Windows

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1607,9 +1607,6 @@ module Addressable
           key = key.to_s if key.kind_of?(Symbol)
           [key, value]
         end
-        # Useful default for OAuth and caching.
-        # Only to be used for non-Array inputs. Arrays should preserve order.
-        new_query_values.sort!
       end
 
       # new_query_values have form [['key1', 'value1'], ['key2', 'value2']]

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -5696,7 +5696,7 @@ describe Addressable::URI, "when assigning query values" do
     @uri.query.should == nil
   end
 
-  it "should maintain original ordering: {'ab' => 'c', :ab => 'a', :a => 'x'}" do
+  it "maintains original ordering: {'ab' => 'c', :ab => 'a', :a => 'x'}" do
     @uri.query_values = {'ab' => 'c', :ab => 'a', :a => 'x'}
 
     @uri.query.should == "ab=c&ab=a&a=x"

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -5696,9 +5696,10 @@ describe Addressable::URI, "when assigning query values" do
     @uri.query.should == nil
   end
 
-  it "should correctly sort {'ab' => 'c', :ab => 'a', :a => 'x'}" do
+  it "should maintain original ordering: {'ab' => 'c', :ab => 'a', :a => 'x'}" do
     @uri.query_values = {'ab' => 'c', :ab => 'a', :a => 'x'}
-    @uri.query.should == "a=x&ab=a&ab=c"
+
+    @uri.query.should == "ab=c&ab=a&a=x"
   end
 
   it "should correctly assign " +


### PR DESCRIPTION
@sporkmonger 

Re-opening https://github.com/sporkmonger/addressable/pull/229 since this is a 3.0 feature.

Running the build seems to have an issue with the `its` method but none of my code changes that, so not sure what the problem is there.

Added the change the the CHANGELOG.