### PR TITLE
Fix query values swallowing unescaped html

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1546,7 +1546,7 @@ module Addressable
       if new_query && !new_query.respond_to?(:to_str)
         raise TypeError, "Can't convert #{new_query.class} into String."
       end
-      @query = new_query ? new_query.to_str : nil
+      @query = new_query ? CGI.unescapeHTML(new_query.to_str) : nil
 
       # Reset dependent values
       remove_instance_variable(:@normalized_query) if defined?(@normalized_query)

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -18,6 +18,7 @@
 
 require "addressable/version"
 require "addressable/idna"
+require "cgi"
 
 ##
 # Addressable is a library for processing links and URIs.

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -4132,6 +4132,25 @@ describe Addressable::URI, "when parsed from " +
   end
 end
 
+describe Addressable::URI, "when parsed from " \
+                           "'http://example.com/?q=a&amp;q2=b'" do
+  before do
+    @uri = Addressable::URI.parse("http://example.com/?q=a&amp;q2=b")
+  end
+
+  it "should have a query of 'q=a&q2=b'" do
+    expect(@uri.query).to eq("q=a&q2=b")
+  end
+
+  it "should have query_values of {'q' => 'a', 'q2' => 'b'}" do
+    expect(@uri.query_values).to eq("q" => "a", "q2" => "b")
+  end
+
+  it "should have a normalized query of 'q=a&q2=b'" do
+    expect(@uri.normalized_query).to eq("q=a&q2=b")
+  end
+end
+
 describe Addressable::URI, "when parsed from " +
     "'http://example.com/?v=%7E&w=%&x=%25&y=%2B&z=C%CC%A7'" do
   before do


### PR DESCRIPTION
resolves and closes #242

Input URL: `example.com?string=foo&amp;another=bar`

BEFORE:
`uri.query_values => {"string"=>"foo", "amp;another"=>"bar"}`
...
`example.com?amp%3Banother=bar&string=foo&...`

AFTER:
`uri.query_values => {"string"=>"foo", "another"=>"bar"}`
...
`example.com?another=bar&string=foo&...`
