### PR TITLE
Stopped merge!, join!, omit! and normalize! from disabling deferred validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- stopped merge!, join!, omit! and normalize! from disabling deferred validation
+
 # Addressable 2.4.0
 - support for 1.8.x dropped
 - double quotes in a host now raises an error

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -2384,7 +2384,9 @@ module Addressable
     def replace_self(uri)
       # Reset dependent values
       instance_variables.each do |var|
-        remove_instance_variable(var) if instance_variable_defined?(var)
+        if instance_variable_defined?(var) && var != :@validation_deferred
+          remove_instance_variable(var)
+        end
       end
 
       @scheme = uri.scheme


### PR DESCRIPTION
In addressable 2.4 there is a bug, where if you defer validation, then
use merge!, join!, omit! or normalize! inside the block, deferred
validation is disabled immediately and all further modification to the
uri inside the block is validated immediately.

This is happening because those methods all call replace_self, which
removes all instance variables, including the one used to flag whether
validation is deferred or not. Once this has been removed, all calls to
validate are actioned immediately.

This bug causes a performance penalty, and also lots of ruby
warnings ("warning: instance variable @validation_deferred not
initialized").
