### PR TITLE
Fix a failure spec in Ruby 2.4.0dev

### DIFF
--- a/spec/addressable/template_spec.rb
+++ b/spec/addressable/template_spec.rb
@@ -91,7 +91,7 @@ describe "Type conversion" do
     '{hello}' => '1234',
     '{nothing}' => '',
     '{sym}' => 'symbolic',
-    '{decimal}' => '0.1E1'
+    '{decimal}' => RUBY_VERSION < '2.4.0' ? '0.1E1' : '0.1e1'
   }
 end
 


### PR DESCRIPTION
It seems that this behavior will change in Ruby 2.4.0.

## Ruby 2.3.3

```ruby
% ruby -v
ruby 2.3.3p222 (2016-11-21 revision 56859) [x86_64-darwin13]
% irb
irb(main):001:0> require "bigdecimal"
irb(main):002:0> BigDecimal.new("1")      #=> #<BigDecimal:7ffcec17cd20,'0.1E1',9(18)>
irb(main):003:0> BigDecimal.new("1").to_s #=> "0.1E1"
```

## Ruby 2.4.0

```ruby
% ruby -v                                                                                                                  ✹ ✭
ruby 2.4.0dev (2016-12-18 trunk 57108) [x86_64-darwin13]
% irb
> require "bigdecimal"
> BigDecimal.new("1")      #=> 0.1e1
> BigDecimal.new("1").to_s #=> "0.1e1"
```

Thanks.