### PR TITLE
Support byte semantics for templates.

### DIFF
--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -488,6 +488,8 @@ module Addressable
     # @param [Hash] mapping The mapping that corresponds to the pattern.
     # @param [#validate, #transform] processor
     #   An optional processor object may be supplied.
+    # @param [Boolean] normalize_values
+    #   Optional flag to enable/disable unicode normalization. Default: true
     #
     # The object should respond to either the <tt>validate</tt> or
     # <tt>transform</tt> messages or both. Both the <tt>validate</tt> and
@@ -518,7 +520,7 @@ module Addressable
     #     "http://example.com/{?one,two,three}/"
     #   ).partial_expand({"one" => "1", "three" => 3}).pattern
     #   #=> "http://example.com/?one=1{&two}&three=3"
-    def partial_expand(mapping, processor=nil)
+    def partial_expand(mapping, processor=nil, normalize_values=true)
       result = self.pattern.dup
       mapping = normalize_keys(mapping)
       result.gsub!( EXPRESSION ) do |capture|
@@ -533,6 +535,8 @@ module Addressable
     # @param [Hash] mapping The mapping that corresponds to the pattern.
     # @param [#validate, #transform] processor
     #   An optional processor object may be supplied.
+    # @param [Boolean] normalize_values
+    #   Optional flag to enable/disable unicode normalization. Default: true
     #
     # The object should respond to either the <tt>validate</tt> or
     # <tt>transform</tt> messages or both. Both the <tt>validate</tt> and
@@ -583,11 +587,11 @@ module Addressable
     #     ExampleProcessor
     #   ).to_str
     #   #=> Addressable::Template::InvalidTemplateValueError
-    def expand(mapping, processor=nil)
+    def expand(mapping, processor=nil, normalize_values=true)
       result = self.pattern.dup
       mapping = normalize_keys(mapping)
       result.gsub!( EXPRESSION ) do |capture|
-        transform_capture(mapping, capture, processor)
+        transform_capture(mapping, capture, processor, normalize_values)
       end
       return Addressable::URI.parse(result)
     end
@@ -780,6 +784,9 @@ module Addressable
     #   The expression to replace
     # @param [#validate, #transform] processor
     #   An optional processor object may be supplied.
+    # @param [Boolean] normalize_values
+    #   Optional flag to enable/disable unicode normalization. Default: true
+    #
     #
     # The object should respond to either the <tt>validate</tt> or
     # <tt>transform</tt> messages or both. Both the <tt>validate</tt> and
@@ -794,7 +801,7 @@ module Addressable
     # after sending the value to the transform method.
     #
     # @return [String] The expanded expression
-    def transform_capture(mapping, capture, processor=nil)
+    def transform_capture(mapping, capture, processor=nil, normalize_values=true)
       _, operator, varlist = *capture.match(EXPRESSION)
       return_value = varlist.split(',').inject([]) do |acc, varspec|
         _, name, modifier = *varspec.match(VARSPEC)
@@ -814,7 +821,7 @@ module Addressable
               "Can't convert #{value.class} into String or Array."
           end
 
-          value = normalize_value(value)
+          value = normalize_value(value) if normalize_values
 
           if processor == nil || !processor.respond_to?(:transform)
             # Handle percent escaping
@@ -877,7 +884,7 @@ module Addressable
             end
             if processor.respond_to?(:transform)
               transformed_value = processor.transform(name, value)
-              transformed_value = normalize_value(transformed_value)
+              transformed_value = normalize_value(transformed_value) if normalize_values
             end
           end
           acc << [name, transformed_value]

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -724,7 +724,8 @@ module Addressable
     # after sending the value to the transform method.
     #
     # @return [String] The expanded expression
-    def transform_partial_capture(mapping, capture, processor = nil, normalize_values = true)
+    def transform_partial_capture(mapping, capture, processor = nil,
+                                  normalize_values = true)
       _, operator, varlist = *capture.match(EXPRESSION)
 
       vars = varlist.split(',')
@@ -746,7 +747,8 @@ module Addressable
           _, name, _ =  *varspec.match(VARSPEC)
 
           acc << if mapping.key? name
-                   transform_capture(mapping, "{#{op}#{varspec}}", processor, normalize_values)
+                   transform_capture(mapping, "{#{op}#{varspec}}",
+                                     processor, normalize_values)
                  else
                    "{#{op}#{varspec}}"
                  end
@@ -803,7 +805,8 @@ module Addressable
     # after sending the value to the transform method.
     #
     # @return [String] The expanded expression
-    def transform_capture(mapping, capture, processor=nil, normalize_values=true)
+    def transform_capture(mapping, capture, processor=nil,
+                          normalize_values=true)
       _, operator, varlist = *capture.match(EXPRESSION)
       return_value = varlist.split(',').inject([]) do |acc, varspec|
         _, name, modifier = *varspec.match(VARSPEC)
@@ -886,7 +889,9 @@ module Addressable
             end
             if processor.respond_to?(:transform)
               transformed_value = processor.transform(name, value)
-              transformed_value = normalize_value(transformed_value) if normalize_values
+              if normalize_values
+                transformed_value = normalize_value(transformed_value)
+              end
             end
           end
           acc << [name, transformed_value]

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -524,7 +524,7 @@ module Addressable
       result = self.pattern.dup
       mapping = normalize_keys(mapping)
       result.gsub!( EXPRESSION ) do |capture|
-        transform_partial_capture(mapping, capture, processor)
+        transform_partial_capture(mapping, capture, processor, normalize_values)
       end
       return Addressable::Template.new(result)
     end
@@ -708,6 +708,8 @@ module Addressable
     #   The expression to expand
     # @param [#validate, #transform] processor
     #   An optional processor object may be supplied.
+    # @param [Boolean] normalize_values
+    #   Optional flag to enable/disable unicode normalization. Default: true
     #
     # The object should respond to either the <tt>validate</tt> or
     # <tt>transform</tt> messages or both. Both the <tt>validate</tt> and
@@ -722,7 +724,7 @@ module Addressable
     # after sending the value to the transform method.
     #
     # @return [String] The expanded expression
-    def transform_partial_capture(mapping, capture, processor = nil)
+    def transform_partial_capture(mapping, capture, processor = nil, normalize_values = true)
       _, operator, varlist = *capture.match(EXPRESSION)
 
       vars = varlist.split(',')
@@ -744,7 +746,7 @@ module Addressable
           _, name, _ =  *varspec.match(VARSPEC)
 
           acc << if mapping.key? name
-                   transform_capture(mapping, "{#{op}#{varspec}}", processor)
+                   transform_capture(mapping, "{#{op}#{varspec}}", processor, normalize_values)
                  else
                    "{#{op}#{varspec}}"
                  end

--- a/spec/addressable/template_spec.rb
+++ b/spec/addressable/template_spec.rb
@@ -969,6 +969,22 @@ describe Addressable::Template do
         )
       end
     end
+    context "partial expand with unicode values" do
+      subject {
+        Addressable::Template.new("http://example.com/{resource}/{query}/")
+      }
+      it "normalizes unicode by default" do
+        expect(subject.partial_expand("query" => "Cafe\u0301").pattern).to eq(
+          "http://example.com/{resource}/Caf%C3%A9/"
+        )
+      end
+
+      it "does not normalize unicode when byte semantics requested" do
+        expect(subject.partial_expand({"query" => "Cafe\u0301"}, nil, false).pattern).to eq(
+          "http://example.com/{resource}/Cafe%CC%81/"
+        )
+      end
+    end
   end
   describe "Partial expand with strings" do
     context "partial_expand with two simple values" do
@@ -1018,7 +1034,7 @@ describe Addressable::Template do
         Addressable::Template.new("http://example.com/search/{query}/")
       }
       it "normalizes unicode by default" do
-        expect(subject.expand({"query" => "Cafe\u0301"}).to_str).to eq(
+        expect(subject.expand("query" => "Cafe\u0301").to_str).to eq(
           "http://example.com/search/Caf%C3%A9/"
         )
       end

--- a/spec/addressable/template_spec.rb
+++ b/spec/addressable/template_spec.rb
@@ -974,13 +974,15 @@ describe Addressable::Template do
         Addressable::Template.new("http://example.com/{resource}/{query}/")
       }
       it "normalizes unicode by default" do
-        expect(subject.partial_expand("query" => "Cafe\u0301").pattern).to eq(
+        template = subject.partial_expand("query" => "Cafe\u0301")
+        expect(template.pattern).to eq(
           "http://example.com/{resource}/Caf%C3%A9/"
         )
       end
 
       it "does not normalize unicode when byte semantics requested" do
-        expect(subject.partial_expand({"query" => "Cafe\u0301"}, nil, false).pattern).to eq(
+        template = subject.partial_expand({"query" => "Cafe\u0301"}, nil, false)
+        expect(template.pattern).to eq(
           "http://example.com/{resource}/Cafe%CC%81/"
         )
       end
@@ -1034,15 +1036,13 @@ describe Addressable::Template do
         Addressable::Template.new("http://example.com/search/{query}/")
       }
       it "normalizes unicode by default" do
-        expect(subject.expand("query" => "Cafe\u0301").to_str).to eq(
-          "http://example.com/search/Caf%C3%A9/"
-        )
+        uri = subject.expand("query" => "Cafe\u0301").to_str
+        expect(uri).to eq("http://example.com/search/Caf%C3%A9/")
       end
 
       it "does not normalize unicode when byte semantics requested" do
-        expect(subject.expand({"query" => "Cafe\u0301"}, nil, false).to_str).to eq(
-          "http://example.com/search/Cafe%CC%81/"
-        )
+        uri = subject.expand({"query" => "Cafe\u0301"}, nil, false).to_str
+        expect(uri).to eq("http://example.com/search/Cafe%CC%81/")
       end
     end
     context "expand with a processor" do

--- a/spec/addressable/template_spec.rb
+++ b/spec/addressable/template_spec.rb
@@ -970,9 +970,9 @@ describe Addressable::Template do
       end
     end
     context "partial expand with unicode values" do
-      subject {
+      subject do
         Addressable::Template.new("http://example.com/{resource}/{query}/")
-      }
+      end
       it "normalizes unicode by default" do
         template = subject.partial_expand("query" => "Cafe\u0301")
         expect(template.pattern).to eq(
@@ -1032,16 +1032,16 @@ describe Addressable::Template do
   end
   describe "Expand" do
     context "expand with unicode values" do
-      subject {
+      subject do
         Addressable::Template.new("http://example.com/search/{query}/")
-      }
+      end
       it "normalizes unicode by default" do
         uri = subject.expand("query" => "Cafe\u0301").to_str
         expect(uri).to eq("http://example.com/search/Caf%C3%A9/")
       end
 
       it "does not normalize unicode when byte semantics requested" do
-        uri = subject.expand({"query" => "Cafe\u0301"}, nil, false).to_str
+        uri = subject.expand({ "query" => "Cafe\u0301" }, nil, false).to_str
         expect(uri).to eq("http://example.com/search/Cafe%CC%81/")
       end
     end

--- a/spec/addressable/template_spec.rb
+++ b/spec/addressable/template_spec.rb
@@ -1013,6 +1013,22 @@ describe Addressable::Template do
     end
   end
   describe "Expand" do
+    context "expand with unicode values" do
+      subject {
+        Addressable::Template.new("http://example.com/search/{query}/")
+      }
+      it "normalizes unicode by default" do
+        expect(subject.expand({"query" => "Cafe\u0301"}).to_str).to eq(
+          "http://example.com/search/Caf%C3%A9/"
+        )
+      end
+
+      it "does not normalize unicode when byte semantics requested" do
+        expect(subject.expand({"query" => "Cafe\u0301"}, nil, false).to_str).to eq(
+          "http://example.com/search/Cafe%CC%81/"
+        )
+      end
+    end
     context "expand with a processor" do
       subject {
         Addressable::Template.new("http://example.com/search/{query}/")


### PR DESCRIPTION
Addressable is overzealous in interpreting the RFC. Normalization of unicode in template expansion is recommended for user-supplied values only. Addressable shouldn't make any assumptions about whether the value needs normalization -- it's better left to the calling application to decide.

This came up wrt GoogleCloudPlatform/google-cloud-ruby#1364 where Cloud Storage uses byte semantics for resource names. The forced normalization in this library results in incorrect URIs for resources that were created with a different encoding.

This PR keeps the default behavior, but adds an option to skip normalization.

