### PR TITLE
Get tests passing with frozen string literals.

### DIFF
--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -743,7 +743,7 @@ module Addressable
 
       vars
         .zip(operator_sequence(operator).take(vars.length))
-        .reduce("") do |acc, (varspec, op)|
+        .reduce("".dup) do |acc, (varspec, op)|
           _, name, _ =  *varspec.match(VARSPEC)
 
           acc << if mapping.key? name

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -436,7 +436,7 @@ module Addressable
       uri = uri.dup
       # Seriously, only use UTF-8. I'm really not kidding!
       uri.force_encoding("utf-8")
-      leave_encoded.force_encoding("utf-8")
+      leave_encoded = leave_encoded.dup.force_encoding("utf-8")
       result = uri.gsub(/%[0-9a-f]{2}/iu) do |sequence|
         c = sequence[1..3].to_i(16).chr
         c.force_encoding("utf-8")
@@ -847,7 +847,7 @@ module Addressable
       return nil unless self.scheme
       @normalized_scheme ||= begin
         if self.scheme =~ /^\s*ssh\+svn\s*$/i
-          "svn+ssh"
+          "svn+ssh".dup
         else
           Addressable::URI.normalize_component(
             self.scheme.strip.downcase,
@@ -1032,9 +1032,9 @@ module Addressable
         if !current_user && !current_password
           nil
         elsif current_user && current_password
-          "#{current_user}:#{current_password}"
+          "#{current_user}:#{current_password}".dup
         elsif current_user && !current_password
-          "#{current_user}"
+          "#{current_user}".dup
         end
       end
       # All normalized values should be UTF-8
@@ -1101,7 +1101,7 @@ module Addressable
             CharacterClasses::HOST)
           result
         else
-          EMPTY_STR
+          EMPTY_STR.dup
         end
       end
       # All normalized values should be UTF-8
@@ -1421,7 +1421,7 @@ module Addressable
     # @return [String] The components that identify a site.
     def site
       (self.scheme || self.authority) && @site ||= begin
-        site_string = ""
+        site_string = "".dup
         site_string << "#{self.scheme}:" if self.scheme != nil
         site_string << "//#{self.authority}" if self.authority != nil
         site_string
@@ -1440,7 +1440,7 @@ module Addressable
     def normalized_site
       return nil unless self.site
       @normalized_site ||= begin
-        site_string = ""
+        site_string = "".dup
         if self.normalized_scheme != nil
           site_string << "#{self.normalized_scheme}:"
         end
@@ -1508,7 +1508,7 @@ module Addressable
         result = URI.normalize_path(result)
         if result.empty? &&
             ["http", "https", "ftp", "tftp"].include?(self.normalized_scheme)
-          result = SLASH
+          result = SLASH.dup
         end
         result
       end
@@ -1694,7 +1694,7 @@ module Addressable
       end
 
       # new_query_values have form [['key1', 'value1'], ['key2', 'value2']]
-      buffer = ""
+      buffer = "".dup
       new_query_values.each do |key, value|
         encoded_key = URI.encode_component(
           key, CharacterClasses::UNRESERVED


### PR DESCRIPTION
These changes allow Addressable to be used when Ruby's newish frozen string literal feature is enabled (via `RUBYOPT="--enable-frozen-string-literal" when running MRI 2.4.x).

The test suite passes when I have this flag set _and_ I'm using the latest in the git repos for:

* rspec
* rspec-core
* rspec-support
* rspec-expectations
* rspec-mocks
* simplecov
* simplecov-html

I've not updated the Gemfile to include these repos, nor the Travis CI configuration to use the RUBYOPT flag for MRI 2.4+, but I can if you'd like? :)