### PR TITLE
Request URI methods: handle URI with uppercase letters in scheme

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1724,7 +1724,7 @@ module Addressable
     #
     # @return [String] The request URI required for an HTTP request.
     def request_uri
-      return nil if self.absolute? && self.scheme !~ /^https?$/
+      return nil if self.absolute? && self.scheme !~ /^https?$/i
       return (
         (!self.path.empty? ? self.path : SLASH) +
         (self.query ? "?#{self.query}" : EMPTY_STR)
@@ -1739,7 +1739,7 @@ module Addressable
       if !new_request_uri.respond_to?(:to_str)
         raise TypeError, "Can't convert #{new_request_uri.class} into String."
       end
-      if self.absolute? && self.scheme !~ /^https?$/
+      if self.absolute? && self.scheme !~ /^https?$/i
         raise InvalidURIError,
           "Cannot set an HTTP request URI for a non-HTTP URI."
       end

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -955,6 +955,10 @@ describe Addressable::URI, "when frozen" do
     expect(@uri.normalize.query).to eq("a=1")
   end
 
+  it "returns '/%70a%74%68?a=%31' for #request_uri" do
+    expect(@uri.request_uri).to eq("/%70a%74%68?a=%31")
+  end
+
   it "returns '1%323' for #fragment" do
     expect(@uri.fragment).to eq("1%323")
   end
@@ -1971,9 +1975,9 @@ end
 
 # Section 5.1.2 of RFC 2616
 describe Addressable::URI, "when parsed from " +
-    "'http://www.w3.org/pub/WWW/TheProject.html'" do
+    "'HTTP://www.w3.org/pub/WWW/TheProject.html'" do
   before do
-    @uri = Addressable::URI.parse("http://www.w3.org/pub/WWW/TheProject.html")
+    @uri = Addressable::URI.parse("HTTP://www.w3.org/pub/WWW/TheProject.html")
   end
 
   it "should have the correct request URI" do
@@ -2008,7 +2012,7 @@ describe Addressable::URI, "when parsed from " +
 
   it "should correctly convert to a hash" do
     expect(@uri.to_hash).to eq({
-      :scheme => "http",
+      :scheme => "HTTP",
       :user => nil,
       :password => nil,
       :host => "www.w3.org",


### PR DESCRIPTION
I think this is in line with https://tools.ietf.org/html/rfc3986#section-3.1

Close #261 