### PR TITLE
Specify ALLOW_UNASSIGNED flags in Addressable::IDNA.to_ascii/to_unicode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,4 +29,4 @@ group :test, :development do
   end
 end
 
-gem 'idn-ruby', :platform => [:mri_20, :mri_21, :mri_22]
+gem 'idn-ruby', :platform => [:mri_20, :mri_21, :mri_22, :mri_23, :mri_24]

--- a/lib/addressable/idna/native.rb
+++ b/lib/addressable/idna/native.rb
@@ -35,7 +35,7 @@ module Addressable
     def self.to_ascii(value)
       value.to_s.split('.', -1).map do |segment|
         if segment.size > 0 && segment.size < 64
-          IDN::Idna.toASCII(segment)
+          IDN::Idna.toASCII(segment, IDN::Idna::ALLOW_UNASSIGNED)
         elsif segment.size >= 64
           segment
         else
@@ -47,7 +47,7 @@ module Addressable
     def self.to_unicode(value)
       value.to_s.split('.', -1).map do |segment|
         if segment.size > 0 && segment.size < 64
-          IDN::Idna.toUnicode(segment)
+          IDN::Idna.toUnicode(segment, IDN::Idna::ALLOW_UNASSIGNED)
         elsif segment.size >= 64
           segment
         else

--- a/spec/addressable/idna_spec.rb
+++ b/spec/addressable/idna_spec.rb
@@ -134,6 +134,12 @@ shared_examples_for "converting from unicode to ASCII" do
     )).to eq("xn--4ud")
   end
 
+  it "should convert '🌹🌹🌹.ws' correctly" do
+    expect(Addressable::IDNA.to_ascii(
+      "\360\237\214\271\360\237\214\271\360\237\214\271.ws"
+    )).to eq("xn--2h8haa.ws")
+  end
+
   it "should handle two adjacent '.'s correctly" do
     expect(Addressable::IDNA.to_ascii(
       "example..host"
@@ -229,6 +235,12 @@ shared_examples_for "converting from ASCII to unicode" do
     expect(Addressable::IDNA.to_unicode(
       "xn--4ud"
     )).to eq("\341\206\265")
+  end
+
+  it "should convert '🌹🌹🌹.ws' correctly" do
+    expect(Addressable::IDNA.to_unicode(
+      "xn--2h8haa.ws"
+    )).to eq("\360\237\214\271\360\237\214\271\360\237\214\271.ws")
   end
 
   it "should handle two adjacent '.'s correctly" do


### PR DESCRIPTION
This PR fixes the issue that some domains which contains unassigned code points can't convert using idn-ruby.

Related: https://github.com/tootsuite/mastodon/issues/4496