### PR TITLE
Ruby Warnings

### DIFF
--- a/lib/addressable/idna/pure.rb
+++ b/lib/addressable/idna/pure.rb
@@ -151,11 +151,9 @@ module Addressable
         if (starter_cc == 0 &&
             (composite = unicode_compose_pair(starter, ch)) != nil)
           starter = composite
-          startercc = lookup_unicode_combining_class(composite)
         else
           unpacked_result << starter
           starter = ch
-          startercc = cc
         end
       end
       unpacked_result << starter

--- a/lib/addressable/idna/pure.rb
+++ b/lib/addressable/idna/pure.rb
@@ -146,7 +146,6 @@ module Addressable
       starter_cc = 256 if starter_cc != 0
       for i in 1...length
         ch = unpacked[i]
-        cc = lookup_unicode_combining_class(ch)
 
         if (starter_cc == 0 &&
             (composite = unicode_compose_pair(starter, ch)) != nil)

--- a/spec/addressable/idna_spec.rb
+++ b/spec/addressable/idna_spec.rb
@@ -26,9 +26,9 @@ shared_examples_for "converting from unicode to ASCII" do
     expect(Addressable::IDNA.to_ascii("www.google.com")).to eq("www.google.com")
   end
 
-  LONG = 'AcinusFallumTrompetumNullunCreditumVisumEstAtCuadLongumEtCefallum.com'
-  it "should convert '#{LONG}' correctly" do
-    expect(Addressable::IDNA.to_ascii(LONG)).to eq(LONG)
+  long = 'AcinusFallumTrompetumNullunCreditumVisumEstAtCuadLongumEtCefallum.com'
+  it "should convert '#{long}' correctly" do
+    expect(Addressable::IDNA.to_ascii(long)).to eq(long)
   end
 
   it "should convert 'www.詹姆斯.com' correctly" do
@@ -148,9 +148,9 @@ shared_examples_for "converting from unicode to ASCII" do
 end
 
 shared_examples_for "converting from ASCII to unicode" do
-  LONG = 'AcinusFallumTrompetumNullunCreditumVisumEstAtCuadLongumEtCefallum.com'
-  it "should convert '#{LONG}' correctly" do
-    expect(Addressable::IDNA.to_unicode(LONG)).to eq(LONG)
+  long = 'AcinusFallumTrompetumNullunCreditumVisumEstAtCuadLongumEtCefallum.com'
+  it "should convert '#{long}' correctly" do
+    expect(Addressable::IDNA.to_unicode(long)).to eq(long)
   end
 
   it "should return the identity conversion when punycode decode fails" do


### PR DESCRIPTION
Here are fixes for some Ruby-level warnings.
The first two "unused variable" warnings happens under Ruby 2.5 trunk, and the last one can be seen under all versions of Ruby.