### PR TITLE
Travis: jruby-9.1.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 language: ruby
 rvm:
   - jruby-9.0.5.0
-  - jruby-9.1.7.0
+  - jruby-9.1.13.0
   - ruby-head
   - ruby-head-clang
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 language: ruby
 rvm:
   - jruby-9.0.5.0
-  - jruby-9.1.13.0
+  - jruby-9.1.14.0
   - ruby-head
   - ruby-head-clang
   - 2.0.0


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/11/08/jruby-9-1-14-0.html