### PR TITLE
Addressable::URI.heuristic_parse throws exception when uri starts with a digit and has specified port

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -194,7 +194,7 @@ module Addressable
         uri.gsub!(/^file:\/+/, "file:///")
       when uri =~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
         uri.gsub!(/^/, hints[:scheme] + "://")
-      when uri !~ /:\/+/ && hints.key?(:scheme)
+      when uri !~ /:\/+/
         uri.gsub!(/^/, hints[:scheme] + "://")
       end
       match = uri.match(URIREGEX)

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -181,18 +181,20 @@ module Addressable
       hints = {
         :scheme => "http"
       }.merge(hints)
-      case uri
-      when /^http:\/+/
+      case 
+      when uri =~ /^http:\/+/
         uri.gsub!(/^http:\/+/, "http://")
-      when /^https:\/+/
+      when uri =~ /^https:\/+/
         uri.gsub!(/^https:\/+/, "https://")
-      when /^feed:\/+http:\/+/
+      when uri =~ /^feed:\/+http:\/+/
         uri.gsub!(/^feed:\/+http:\/+/, "feed:http://")
-      when /^feed:\/+/
+      when uri =~ /^feed:\/+/
         uri.gsub!(/^feed:\/+/, "feed://")
-      when /^file:\/+/
+      when uri =~ /^file:\/+/
         uri.gsub!(/^file:\/+/, "file:///")
-      when /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
+      when uri =~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
+        uri.gsub!(/^/, hints[:scheme] + "://")
+      when uri !~ /:\/+/ && hints.key?(:scheme)
         uri.gsub!(/^/, hints[:scheme] + "://")
       end
       match = uri.match(URIREGEX)
@@ -205,9 +207,6 @@ module Addressable
         uri[offset[0]...offset[1]] = new_authority
       end
       parsed = self.parse(uri)
-      if parsed.scheme =~ /^[^\/?#\.]+\.[^\/?#]+$/
-        parsed = self.parse(hints[:scheme] + "://" + uri)
-      end
       if parsed.path.include?(".")
         new_host = parsed.path[/^([^\/]+\.[^\/]*)/, 1]
         if new_host

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -181,20 +181,20 @@ module Addressable
       hints = {
         :scheme => "http"
       }.merge(hints)
-      if uri =~ /^http:\/+/ then
-        uri.gsub!(/^http:\/+/, "http://")
-      elsif uri =~ /^https:\/+/ then
-        uri.gsub!(/^https:\/+/, "https://")
-      elsif uri =~ /^feed:\/+http:\/+/ then
-        uri.gsub!(/^feed:\/+http:\/+/, "feed:http://")
-      elsif uri =~ /^feed:\/+/ then
-        uri.gsub!(/^feed:\/+/, "feed://")
-      elsif uri =~ /^file:\/+/ then
-        uri.gsub!(/^file:\/+/, "file:///")
-      elsif uri =~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/ then
-        uri.gsub!(/^/, hints[:scheme] + "://")
-      elsif uri !~ /:\/+/ then
-        uri.gsub!(/^/, hints[:scheme] + "://")
+      if uri =~ %r{^http:\/+} then
+        uri.gsub!(%r{^http:\/+}, "http://")
+      elsif uri =~ %r{^https:\/+}
+        uri.gsub!(%r{^https:\/+}, "https://")
+      elsif uri =~ %r{^feed:\/+http:\/+}
+        uri.gsub!(%r{^feed:\/+http:\/+/}, "feed:http://")
+      elsif uri =~ %r{^feed:\/+}
+        uri.gsub!(%r{^feed:\/+}, "feed://")
+      elsif uri =~ %{^file:\/+}
+        uri.gsub!(%r{^file:\/+}, "file:///")
+      elsif uri =~ %r{^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}}
+        uri.gsub!(%r{^}, hints[:scheme] + "://")
+      elsif uri !~ %r{:\/+}
+        uri.gsub!(%r{^}, hints[:scheme] + "://")
       end
       match = uri.match(URIREGEX)
       fragments = match.captures

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -181,20 +181,20 @@ module Addressable
       hints = {
         :scheme => "http"
       }.merge(hints)
-      if uri =~ %r{^http:\/+} then
-        uri.gsub!(%r{^http:\/+}, "http://")
-      elsif uri =~ %r{^https:\/+}
-        uri.gsub!(%r{^https:\/+}, "https://")
-      elsif uri =~ %r{^feed:\/+http:\/+}
-        uri.gsub!(%r{^feed:\/+http:\/+/}, "feed:http://")
-      elsif uri =~ %r{^feed:\/+}
-        uri.gsub!(%r{^feed:\/+}, "feed://")
-      elsif uri =~ %{^file:\/+}
-        uri.gsub!(%r{^file:\/+}, "file:///")
-      elsif uri =~ %r{^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}}
-        uri.gsub!(%r{^}, hints[:scheme] + "://")
-      elsif uri !~ %r{:\/+}
-        uri.gsub!(%r{^}, hints[:scheme] + "://")
+      if uri =~ /^http:\/+/ then
+        uri.gsub!(/^http:\/+/, "http://")
+      elsif uri =~ /^https:\/+/ then
+        uri.gsub!(/^https:\/+/, "https://")
+      elsif uri =~ /^feed:\/+http:\/+/ then
+        uri.gsub!(/^feed:\/+http:\/+/, "feed:http://")
+      elsif uri =~ /^feed:\/+/ then
+        uri.gsub!(/^feed:\/+/, "feed://")
+      elsif uri =~ /^file:\/+/ then
+        uri.gsub!(/^file:\/+/, "file:///")
+      elsif uri =~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/ then
+        uri.gsub!(/^/, hints[:scheme] + "://")
+      elsif uri !~ /:\/+/ then
+        uri.gsub!(/^/, hints[:scheme] + "://")
       end
       match = uri.match(URIREGEX)
       fragments = match.captures

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -181,19 +181,19 @@ module Addressable
       hints = {
         :scheme => "http"
       }.merge(hints)
-      if uri =~ /^http:\/+/ then
+      if uri =~ /^http:\/+/
         uri.gsub!(/^http:\/+/, "http://")
-      elsif uri =~ /^https:\/+/ then
+      elsif uri =~ /^https:\/+/
         uri.gsub!(/^https:\/+/, "https://")
-      elsif uri =~ /^feed:\/+http:\/+/ then
+      elsif uri =~ /^feed:\/+http:\/+/
         uri.gsub!(/^feed:\/+http:\/+/, "feed:http://")
-      elsif uri =~ /^feed:\/+/ then
+      elsif uri =~ /^feed:\/+/
         uri.gsub!(/^feed:\/+/, "feed://")
-      elsif uri =~ /^file:\/+/ then
+      elsif uri =~ /^file:\/+/
         uri.gsub!(/^file:\/+/, "file:///")
-      elsif uri =~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/ then
+      elsif uri =~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
         uri.gsub!(/^/, hints[:scheme] + "://")
-      elsif uri !~ /:\/+/ then
+      elsif uri !~ /:\/+/
         uri.gsub!(/^/, hints[:scheme] + "://")
       end
       match = uri.match(URIREGEX)

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -181,20 +181,19 @@ module Addressable
       hints = {
         :scheme => "http"
       }.merge(hints)
-      case 
-      when uri =~ /^http:\/+/
+      if uri =~ /^http:\/+/ then
         uri.gsub!(/^http:\/+/, "http://")
-      when uri =~ /^https:\/+/
+      elsif uri =~ /^https:\/+/ then
         uri.gsub!(/^https:\/+/, "https://")
-      when uri =~ /^feed:\/+http:\/+/
+      elsif uri =~ /^feed:\/+http:\/+/ then
         uri.gsub!(/^feed:\/+http:\/+/, "feed:http://")
-      when uri =~ /^feed:\/+/
+      elsif uri =~ /^feed:\/+/ then
         uri.gsub!(/^feed:\/+/, "feed://")
-      when uri =~ /^file:\/+/
+      elsif uri =~ /^file:\/+/ then
         uri.gsub!(/^file:\/+/, "file:///")
-      when uri =~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
+      elsif uri =~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/ then
         uri.gsub!(/^/, hints[:scheme] + "://")
-      when uri !~ /:\/+/
+      elsif uri !~ /:\/+/ then
         uri.gsub!(/^/, hints[:scheme] + "://")
       end
       match = uri.match(URIREGEX)


### PR DESCRIPTION
Reproducing the bug:

```
2.3.1 :001 > require 'addressable'
2.3.1 :002 > Addressable::URI.heuristic_parse('123.example.com:8080')
Addressable::URI::InvalidURIError: Invalid scheme format: 123.example.com
        from /home/vlad/.rvm/gems/ruby-2.3.1/gems/addressable-2.5.2/lib/addressable/uri.rb:874:in `scheme='
        from /home/vlad/.rvm/gems/ruby-2.3.1/gems/addressable-2.5.2/lib/addressable/uri.rb:799:in `block in initialize'
        from /home/vlad/.rvm/gems/ruby-2.3.1/gems/addressable-2.5.2/lib/addressable/uri.rb:2355:in `defer_validation'
        from /home/vlad/.rvm/gems/ruby-2.3.1/gems/addressable-2.5.2/lib/addressable/uri.rb:796:in `initialize'
        from /home/vlad/.rvm/gems/ruby-2.3.1/gems/addressable-2.5.2/lib/addressable/uri.rb:136:in `new'
        from /home/vlad/.rvm/gems/ruby-2.3.1/gems/addressable-2.5.2/lib/addressable/uri.rb:136:in `parse'
        from /home/vlad/.rvm/gems/ruby-2.3.1/gems/addressable-2.5.2/lib/addressable/uri.rb:207:in `heuristic_parse'
        from (irb):4
        from /home/vlad/.rvm/rubies/ruby-2.3.1/bin/irb:11:in `<main>'
```
That happens because [heuristic_parse](https://github.com/sporkmonger/addressable/blob/master/lib/addressable/uri.rb#L207-L210)  first tries to parse `uri` and then it looks if `parser.scheme` has invalid characters, if so it tries to parse once again the same `uri` with prefixed sheme. The fix is essentially to add sheme prefix before first parse if `uri` doesn't have `://` as substring