### PR TITLE
remove deprecated warning

### DIFF
--- a/spec/addressable/template_spec.rb
+++ b/spec/addressable/template_spec.rb
@@ -82,7 +82,7 @@ describe "Type conversion" do
       :hello => 1234,
       :nothing => nil,
       :sym => :symbolic,
-      :decimal => BigDecimal.new('1')
+      :decimal => BigDecimal('1')
     }
   }
 


### PR DESCRIPTION
BigDecimal.new is deprecated in Ruby2.5

```
spec/addressable/template_spec.rb:85: warning: BigDecimal.new is deprecated; use Kernel.BigDecimal method instead.
```