### PR TITLE
Handle arrays in query params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ doc
 heckling
 pkg
 specdoc
+.byebug_history

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1645,7 +1645,13 @@ module Addressable
           pair[1] = URI.unencode_component(pair[1].to_str.gsub(/\+/, " "))
         end
         if return_type == Hash
-          accu[pair[0]] = pair[1]
+          if pair[0].end_with? '[]'
+            pair[0].chomp! '[]'
+            accu[pair[0]] = [] unless accu.key?(pair[0])
+            accu[pair[0]] << pair[1]
+          else
+            accu[pair[0]] = pair[1]
+          end
         else
           accu << pair
         end

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1706,7 +1706,7 @@ module Addressable
             encoded_value = URI.encode_component(
               sub_value, CharacterClasses::UNRESERVED
             )
-            buffer << "#{encoded_key}=#{encoded_value}&"
+            buffer << "#{encoded_key}%5B%5D=#{encoded_value}&"
           end
         else
           encoded_value = URI.encode_component(

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1645,14 +1645,17 @@ module Addressable
           pair[1] = URI.unencode_component(pair[1].to_str.gsub(/\+/, " "))
         end
         if return_type == Hash
-          if pair[0].end_with? '[]'
-            pair[0].chomp! '[]'
+          if pair[0].end_with? "[]"
+            pair[0].chomp! "[]"
             accu[pair[0]] = [] unless accu.key?(pair[0])
             accu[pair[0]] << pair[1]
           else
             accu[pair[0]] = pair[1]
           end
         else
+          if pair[0].end_with? "[]"
+            pair[0].chomp! "[]"
+          end
           accu << pair
         end
         accu

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1709,19 +1709,19 @@ module Addressable
           key, CharacterClasses::UNRESERVED
         )
         if value == nil
-          buffer << encoded_key << '&'
+          buffer << encoded_key << "&"
         elsif value.kind_of?(Array)
           value.each do |sub_value|
             encoded_value = URI.encode_component(
               sub_value, CharacterClasses::UNRESERVED
             )
-            buffer << encoded_key << '%5B%5D=' << encoded_value << '&'
+            buffer << encoded_key << "%5B%5D=" << encoded_value << "&"
           end
         else
           encoded_value = URI.encode_component(
             value, CharacterClasses::UNRESERVED
           )
-          buffer << encoded_key << '=' << encoded_value << '&'
+          buffer << encoded_key << "=" << encoded_value << "&"
         end
       end
       self.query = buffer.chop

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1709,19 +1709,19 @@ module Addressable
           key, CharacterClasses::UNRESERVED
         )
         if value == nil
-          buffer << "#{encoded_key}&"
+          buffer << encoded_key << '&'
         elsif value.kind_of?(Array)
           value.each do |sub_value|
             encoded_value = URI.encode_component(
               sub_value, CharacterClasses::UNRESERVED
             )
-            buffer << "#{encoded_key}%5B%5D=#{encoded_value}&"
+            buffer << encoded_key << '%5B%5D=' << encoded_value << '&'
           end
         else
           encoded_value = URI.encode_component(
             value, CharacterClasses::UNRESERVED
           )
-          buffer << "#{encoded_key}=#{encoded_value}&"
+          buffer << encoded_key << '=' << encoded_value << '&'
         end
       end
       self.query = buffer.chop

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -4944,14 +4944,14 @@ describe Addressable::URI, "when parsed from " +
 
   it "should have correct query values" do
     expect(@uri.query_values(Hash)).to eq(
-      {"one[two][three]" => ["four", "five"]}
-      )
+      "one[two][three]" => %w(four five)
+    )
   end
 
   it "should have correct array query values" do
     expect(@uri.query_values(Array)).to eq(
       [["one[two][three]", "four"], ["one[two][three]", "five"]]
-      )
+    )
   end
 end
 

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -6282,7 +6282,7 @@ describe Addressable::URI, "when assigning query values" do
 
   it "should correctly assign {:a => 'a', :b => ['c', 'd', 'e']}" do
     @uri.query_values = {:a => "a", :b => ["c", "d", "e"]}
-    expect(@uri.query).to eq("a=a&b=c&b=d&b=e")
+    expect(@uri.query).to eq("a=a&b%5B%5D=c&b%5B%5D=d&b%5B%5D=e")
   end
 
   it "should raise an error attempting to assign {'a' => {'b' => ['c']}}" do

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -4943,15 +4943,15 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have correct query values" do
-    expect(@uri.query_values(Hash)).to eq({
-      "one[two][three]" => ["four", "five"]
-    })
+    expect(@uri.query_values(Hash)).to eq(
+      {"one[two][three]" => ["four", "five"]}
+      )
   end
 
   it "should have correct array query values" do
-    expect(@uri.query_values(Array)).to eq([
-      ["one[two][three]", "four"], ["one[two][three]", "five"]
-    ])
+    expect(@uri.query_values(Array)).to eq(
+      [["one[two][three]", "four"], ["one[two][three]", "five"]]
+      )
   end
 end
 

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -4943,12 +4943,14 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have correct query values" do
-    expect(@uri.query_values(Hash)).to eq({"one[two][three]" => ["four", "five"]})
+    expect(@uri.query_values(Hash)).to eq({
+      "one[two][three]" => ["four", "five"]
+    })
   end
 
   it "should have correct array query values" do
     expect(@uri.query_values(Array)).to eq([
-      ["one[two][three][]", "four"], ["one[two][three][]", "five"]
+      ["one[two][three]", "four"], ["one[two][three]", "five"]
     ])
   end
 end

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -4943,7 +4943,7 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have correct query values" do
-    expect(@uri.query_values(Hash)).to eq({"one[two][three][]" => "five"})
+    expect(@uri.query_values(Hash)).to eq({"one[two][three]" => ["four", "five"]})
   end
 
   it "should have correct array query values" do


### PR DESCRIPTION
As noted in #282 by @PetrKaleta there's some weird behavior when passing in array params.

```ruby
uri = Addressable::URI.parse 'http://foo.com/'
uri.query_values = { 'abc' => ['123', '456'] }
uri.to_s
# => http://foo.com/?abc=123&abc=456
```

And parsing that back returns

```ruby
Addressable::URI.parse(uri.to_s).query_values
# => {"abc"=>"456"}
```

Perhaps instead it should give the URL

```ruby
# => http://foo.com/?abc%5B%5D=123&abc%5B%5D=456
```

Because parsing that out returns what was sent in

```ruby
Addressable::URI.parse(uri.to_s).query_values
# => {"abc"=>["123", "456"]}
```
