### PR TITLE
Travis: jruby-9.1.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 language: ruby
 rvm:
   - jruby-9.0.5.0
-  - jruby-9.1.14.0
+  - jruby-9.1.16.0
   - ruby-head
   - ruby-head-clang
   - 2.0.0


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2018/02/21/jruby-9-1-16-0.html