### PR TITLE
the method for redefinition basename

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1605,6 +1605,20 @@ module Addressable
     end
 
     ##
+    # Sets the basename component for this URI.
+    #
+    # @param [String, #to_str] new_basename. The new basename value
+    def basename=(new_basename)
+      self.path = begin
+        if path.empty? || path == "/"
+          new_basename
+        else
+          path.sub(%r{\b#{basename}(\/)?\z}, new_basename)
+        end
+      end
+    end
+
+    ##
     # The extname, if any, of the file in the path component.
     # Empty string if there is no extension.
     #

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -5601,6 +5601,22 @@ describe Addressable::URI, "when given the tld " do
   end
 end
 
+describe Addressable::URI, "when given the input" \
+    "'http://test.com/category/sub_category/categories'" do
+  before do
+    @input = "http://test.com/category/sub_category/categories"
+  end
+
+  it "should have former path but with the new basename: 'category' "\
+     "when the replaceable basename is contained in uri path" do
+    # to prevent regressions of path, for example shouldn't be: http://test.com/category
+    uri = Addressable::URI.parse(@input)
+    uri.basename = "category"
+
+    expect(uri.to_s).to eq("http://test.com/category/sub_category/category")
+  end
+end
+
 describe Addressable::URI, "when given the path " +
     "'c:\\windows\\My Documents 100%20\\foo.txt'" do
   before do
@@ -6062,6 +6078,13 @@ describe Addressable::URI, "when given the input " +
     @input = "http://example.com/"
   end
 
+  it "should set the new basename: 'index.html'" do
+    uri = Addressable::URI.parse(@input)
+
+    expect(uri.basename = "index.html").to eq("index.html")
+    expect(uri.to_s).to eq("http://example.com/index.html")
+  end
+
   it "should heuristically parse to 'http://example.com/'" do
     @uri = Addressable::URI.heuristic_parse(@input)
     expect(@uri.to_s).to eq("http://example.com/")
@@ -6126,6 +6149,20 @@ describe Addressable::URI, "when given the input " +
     "'http://example.com/example.com/'" do
   before do
     @input = "http://example.com/example.com/"
+  end
+
+  it "should have the correct basename: 'example.com'" do
+    uri = Addressable::URI.parse(@input)
+    uri.basename = "example.com"
+
+    expect(uri.basename).to eq("example.com")
+  end
+
+  it "should change the basename into 'categories'" do
+    uri = Addressable::URI.parse(@input)
+
+    expect(uri.basename = "categories").to eq("categories")
+    expect(uri.to_s).to eq("http://example.com/categories")
   end
 
   it "should heuristically parse to 'http://example.com/example.com/'" do


### PR DESCRIPTION
Hi, thanks again for the gem

The point is: 
there are often situations where we need to change the basename

for example iteration through sections of the site:
```
url = Addressable::URI.parse("http://example.com/sections/categories/sub_categories/")

xpath("//a[@class='sub-categories']").each do |a|
  # when links contains only basenames
  a[:href] = "subcategory_1"
  # and also correct link should be "http://example.com/sections/categories/subcategory_1"
  # so in this case we have problems with fast and easy address replacement
  # especially if we need to save the `url` Addressable object, for later use in other methods

  # or we need to quickly set the basename and save it in the object, without re-parse
  # this is just few examples of which can be solved differently, but it seems to me, it would be more  convenient to have such a method directly here

  # example with method 'basename=':
  url.basename = a[:href]
  page.visit(url.to_s) # http://example.com/sections/categories/subcategory_1
end
```

I would be grateful for the views on this matter, thanks