### PR TITLE
Implicit blocks are much faster than explicit one

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -2367,10 +2367,10 @@ module Addressable
     #
     # @param [Proc] block
     #   A set of operations to perform on a given URI.
-    def defer_validation(&block)
-      raise LocalJumpError, "No block given." unless block
+    def defer_validation
+      raise LocalJumpError, "No block given." unless block_given?
       @validation_deferred = true
-      block.call()
+      yield
       @validation_deferred = false
       validate
       return nil


### PR DESCRIPTION
Ref: https://github.com/JuanitoFatas/fast-ruby#proccall-and-block-arguments-vs-yieldcode