### PR TITLE
Adds the ability to expand existing templates with additional variables.

### DIFF
--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -616,7 +616,9 @@ module Addressable
     #.../resources{?second_variable,third_variable}
     # @return [Addressable::Template] The template generated after attaching all new variables
     def attach_variables(*variables)
-      variables.reduce(self) { |template, variable| template.attach_variable(variable) }
+      variables.inject(self) do |template, variable|
+        template.attach_variable(variable)
+      end
     end
 
     ##
@@ -711,7 +713,7 @@ module Addressable
     FINISHING_PARAMS_EXPRESSION = /\{[\?&](#{varspec}(?:,#{varspec})*)\}$/
 
     ##
-    # @return [Boolean] If the patterns ends in expression that describes a variable
+    # @return [Boolean] The patterns ends in anexpression describing a variable
     # @api private
     def ends_in_param_variable?
       pattern.match(FINISHING_PARAMS_EXPRESSION)
@@ -720,7 +722,7 @@ module Addressable
     CONTAIN_PARAMS = /\?#{variable}/
 
     ##
-    # @return [Boolean] If the patterns contains params
+    # @return [Boolean] The patterns contains params
     # @api private
     def contain_params?
       pattern.match(CONTAIN_PARAMS)
@@ -732,11 +734,13 @@ module Addressable
     # @param variable [String] The variable being appended to the Template
     #
     # @example
-    # for a pattern including ending in ...?variable=value{&second_variable}
+    # for a pattern including ending in:
+    # ...?variable=value{&second_variable}
     # when attaching the variable: third_variable
-    # we expect a new template with a pattern ending in ...?variable=value{&second_variable,third_variable}
+    # we expect a new template with a pattern ending in:
+    # ...?variable=value{&second_variable,third_variable}
     #
-    # @return [Addressable::Template] The template generated after attaching a new variable
+    # @return [Addressable::Template] The template generated after attaching the variable
     # @api private
     def attach_variable(variable)
       raise NotAVariableError, "#{variable} is not a valid variable" unless variable.match(VARNAME)

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -612,7 +612,7 @@ module Addressable
     # .../resources
     # when calling `attach_variables('second_variable', 'third_variable')`
     # we expect a new template with a pattern ending in
-    #.../resources{?second_variable,third_variable}
+    # .../resources{?second_variable,third_variable}
     # @return [Addressable::Template] The template generated after attaching all new variables
     def attach_variables(*variables)
       variables.inject(self) do |template, variable|

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -48,7 +48,6 @@ module Addressable
       "(?:#{var_char}(?:\\.?#{var_char})*)"
     varspec =
       "(?:(#{variable})(\\*|:\\d+)?)"
-
     VARNAME =
       /^#{variable}$/
     VARSPEC =

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -723,7 +723,7 @@ module Addressable
     ##
     # @return [Boolean] The patterns contains params
     # @api private
-    def contain_params?
+    def contains_params?
       pattern.match(CONTAIN_PARAMS)
     end
 
@@ -744,9 +744,17 @@ module Addressable
     def attach_variable(variable)
       raise NotAVariableError, "#{variable} is not a valid variable" unless variable.match(VARNAME)
       if ends_in_param_variable?
-        new_expression = "#{pattern[pattern.index(FINISHING_PARAMS_EXPRESSION)..-2]},#{variable}}"
-        new_pattern = pattern[0...pattern.index(FINISHING_PARAMS_EXPRESSION)] + new_expression
-      elsif contain_params?
+        # Fetches the last expression
+        position_of_last_expression = pattern.index(FINISHING_PARAMS_EXPRESSION)
+        prior_last_expression = pattern[position_of_last_expression..-1]
+        patern_without_last_expression = pattern[0...position_of_last_expression]
+        # Extracts the external curly brackets: "{...}"
+        open_last_expression = prior_last_expression[1...-1]
+        # Attaches the variable and re-adds the curly brackets
+        new_expression = "{#{open_last_expression},#{variable}}"
+        # Re constructs the pattern
+        new_pattern = "#{patern_without_last_expression}#{new_expression}"
+      elsif contains_params?
         new_pattern = "#{pattern}{&#{variable}}"
       else
         new_pattern = "#{pattern}{?#{variable}}"

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -603,7 +603,8 @@ module Addressable
     end
 
     ##
-    # Creates a new template in which a new variable is appended at the end of the pattern.
+    # Creates a new template:
+    # A new variable is appended at the end of the pattern.
     # Generally you should be using: attach_variables rather than this.
     # @param variables [*String] The variable being appended to the Template
     #
@@ -613,7 +614,7 @@ module Addressable
     # when calling `attach_variables('second_variable', 'third_variable')`
     # we expect a new template with a pattern ending in
     # .../resources{?second_variable,third_variable}
-    # @return [Addressable::Template] The template generated after attaching all new variables
+    # @return [Addressable::Template] The new template with more variables
     def attach_variables(*variables)
       variables.inject(self) do |template, variable|
         template.attach_variable(variable)
@@ -739,21 +740,22 @@ module Addressable
     # we expect a new template with a pattern ending in:
     # ...?variable=value{&second_variable,third_variable}
     #
-    # @return [Addressable::Template] The template generated after attaching the variable
+    # @return [Addressable::Template] Thew new template with the variable
     # @api private
     def attach_variable(variable)
-      raise NotAVariableError, "#{variable} is not a valid variable" unless variable.match(VARNAME)
+      raise NotAVariableError,
+            "#{variable} is not a valid variable" unless variable.match(VARNAME)
       if ends_in_param_variable?
         # Fetches the last expression
         position_of_last_expression = pattern.index(FINISHING_PARAMS_EXPRESSION)
         prior_last_expression = pattern[position_of_last_expression..-1]
-        patern_without_last_expression = pattern[0...position_of_last_expression]
+        without_last_expression = pattern[0...position_of_last_expression]
         # Extracts the external curly brackets: "{...}"
         open_last_expression = prior_last_expression[1...-1]
         # Attaches the variable and re-adds the curly brackets
         new_expression = "{#{open_last_expression},#{variable}}"
         # Re constructs the pattern
-        new_pattern = "#{patern_without_last_expression}#{new_expression}"
+        new_pattern = "#{without_last_expression}#{new_expression}"
       elsif contains_params?
         new_pattern = "#{pattern}{&#{variable}}"
       else

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -743,8 +743,10 @@ module Addressable
     # @return [Addressable::Template] Thew new template with the variable
     # @api private
     def attach_variable(variable)
-      raise NotAVariableError,
-            "#{variable} is not a valid variable" unless variable.match(VARNAME)
+      unless variable.match(VARNAME)
+        raise NotAVariableError, "#{variable} is not a valid variable"
+      end
+
       if ends_in_param_variable?
         # Fetches the last expression
         position_of_last_expression = pattern.index(FINISHING_PARAMS_EXPRESSION)

--- a/spec/addressable/template_spec.rb
+++ b/spec/addressable/template_spec.rb
@@ -1352,12 +1352,16 @@ describe Addressable::Template do
       context "a single variable" do
         it "represents the variable" do
           result = uri.attach_variables("description")
-          expect(result.pattern).to eq "http://example.com/resources{?description}"
+          expect(result.pattern).to eq(
+            "http://example.com/resources{?description}"
+          )
         end
 
         context "when it is invalid" do
           it "raises an error" do
-            expect { uri.attach_variables("%invalid") }.to raise_error(Addressable::Template::NotAVariableError)
+            expect { uri.attach_variables("%invalid") }.to(
+              raise_error(Addressable::Template::NotAVariableError)
+            )
           end
         end
       end
@@ -1365,13 +1369,20 @@ describe Addressable::Template do
       context "multiple variables" do
         it "can partially expand the variable" do
           result = uri.attach_variables("description", "name")
-          expect(result.pattern).to eq "http://example.com/resources{?description,name}"
+          expect(result.pattern).to eq(
+            "http://example.com/resources{?description,name}"
+          )
           result = result.attach_variables("last_name")
-          expect(result.pattern).to eq "http://example.com/resources{?description,name,last_name}"
+          expect(result.pattern).to eq(
+            "http://example.com/resources{?description,name,last_name}"
+          )
         end
 
         context "when one of them is invalid" do
-          subject(:attach_invalid) { -> { uri.attach_variables("valid_var", "%invalid") } }
+          subject(:attach_invalid) do
+            -> { uri.attach_variables("valid_var", "%invalid") }
+          end
+
           it { is_expected.to raise_error(Addressable::Template::NotAVariableError) }
           it { is_expected.to raise_error(/%invalid/) }
           it { is_expected.not_to raise_error(/valid_var/) }
@@ -1379,13 +1390,21 @@ describe Addressable::Template do
 
         it "matches matching URIs" do
           result = uri.attach_variables("description", "name")
-          expect(result).to eq Addressable::Template.new("http://example.com/resources{?description,name}")
+          expect(result).to eq(
+            Addressable::Template.new(
+              "http://example.com/resources{?description,name}"
+            )
+          )
         end
       end
     end
 
     context "when the URI contained variables" do
-      let(:original_template) { Addressable::Template.new("http://example.com/resources{/id}{?decorated}") }
+      let(:original_template) do
+        Addressable::Template.new(
+          "http://example.com/resources{/id}{?decorated}"
+        )
+      end
       let(:result) { original_template.attach_variables("expanded") }
 
       it "maintains the original variables" do
@@ -1395,45 +1414,58 @@ describe Addressable::Template do
 
       it "attaches the new variables" do
         expect(result.variables).to include "expanded"
-        expect(result.pattern).to eq "http://example.com/resources{/id}{?decorated,expanded}"
+        expect(result.pattern).to eq(
+          "http://example.com/resources{/id}{?decorated,expanded}"
+        )
       end
 
       it "allows you to expand both previous and new variables" do
-        expect(result.partial_expand(id: 3, decorated: true).pattern)
-          .to eq "http://example.com/resources/3?decorated=true{&expanded}"
+        expect(result.partial_expand(id: 3, decorated: true).pattern).to eq(
+          "http://example.com/resources/3?decorated=true{&expanded}"
+        )
       end
 
       context "when the last variable is part of the URI" do
-        let(:original_template) { Addressable::Template.new("http://example.com/resources{/id}") }
+        let(:original_template) do
+          Addressable::Template.new("http://example.com/resources{/id}")
+        end
 
         it "attaches the new variables" do
           expect(result.variables).to include "expanded"
-          expect(result.pattern).to eq "http://example.com/resources{/id}{?expanded}"
+          expect(result.pattern).to eq(
+            "http://example.com/resources{/id}{?expanded}"
+          )
         end
       end
 
       context "when the URI was partially expanded" do
         context "with a trailing param" do
           let(:original_template) do
-            Addressable::Template.new("http://example.com/resources{/id}{?decorated,translated,additional}")
-              .partial_expand(id: 14, decorated: true, translated: "es")
+            Addressable::Template.new(
+              "http://example.com/resources{/id}{?decorated,translated,additional}"
+            ).partial_expand(id: 14, decorated: true, translated: "es")
           end
 
           it "attaches the new variables" do
             expect(result.variables).to include "expanded"
-            expect(result.pattern).to eq "http://example.com/resources/14?decorated=true&translated=es{&additional,expanded}"
+            expect(result.pattern).to eq(
+              "http://example.com/resources/14?decorated=true&translated=es{&additional,expanded}"
+            )
           end
         end
 
         context "without trailing params" do
           let(:original_template) do
-            Addressable::Template.new("http://example.com/resources{/id}{?decorated}")
-              .partial_expand(id: 14, decorated: true)
+            Addressable::Template.new(
+              "http://example.com/resources{/id}{?decorated}"
+            ).partial_expand(id: 14, decorated: true)
           end
 
           it "attaches the new variables" do
             expect(result.variables).to include "expanded"
-            expect(result.pattern).to eq "http://example.com/resources/14?decorated=true{&expanded}"
+            expect(result.pattern).to eq(
+              "http://example.com/resources/14?decorated=true{&expanded}"
+            )
           end
         end
       end

--- a/spec/addressable/template_spec.rb
+++ b/spec/addressable/template_spec.rb
@@ -1345,95 +1345,95 @@ describe Addressable::Template do
     end
   end
 
-  describe 'Adding variables' do
-    context 'when the URI did not contain them' do
-      let(:uri) { Addressable::Template.new('http://example.com/resources') }
+  describe "Adding variables" do
+    context "when the URI did not contain them" do
+      let(:uri) { Addressable::Template.new("http://example.com/resources") }
 
-      context 'a single variable' do
-        it 'represents the variable' do
-          result = uri.attach_variables('description')
-          expect(result.pattern).to eq 'http://example.com/resources{?description}'
+      context "a single variable" do
+        it "represents the variable" do
+          result = uri.attach_variables("description")
+          expect(result.pattern).to eq "http://example.com/resources{?description}"
         end
 
-        context 'when it is invalid' do
-          it 'raises an error' do
-            expect { uri.attach_variables('%invalid') }.to raise_error(Addressable::Template::NotAVariableError)
+        context "when it is invalid" do
+          it "raises an error" do
+            expect { uri.attach_variables("%invalid") }.to raise_error(Addressable::Template::NotAVariableError)
           end
         end
       end
 
-      context 'multiple variables' do
-        it 'can partially expand the variable' do
-          result = uri.attach_variables('description', 'name')
-          expect(result.pattern).to eq 'http://example.com/resources{?description,name}'
-          result = result.attach_variables('last_name')
-          expect(result.pattern).to eq 'http://example.com/resources{?description,name,last_name}'
+      context "multiple variables" do
+        it "can partially expand the variable" do
+          result = uri.attach_variables("description", "name")
+          expect(result.pattern).to eq "http://example.com/resources{?description,name}"
+          result = result.attach_variables("last_name")
+          expect(result.pattern).to eq "http://example.com/resources{?description,name,last_name}"
         end
 
-        context 'when one of them is invalid' do
-          subject(:attach_invalid) { -> { uri.attach_variables('valid_var', '%invalid') } }
+        context "when one of them is invalid" do
+          subject(:attach_invalid) { -> { uri.attach_variables("valid_var", "%invalid") } }
           it { is_expected.to raise_error(Addressable::Template::NotAVariableError) }
           it { is_expected.to raise_error(/%invalid/) }
           it { is_expected.not_to raise_error(/valid_var/) }
         end
 
-        it 'matches matching URIs' do
-          result = uri.attach_variables('description', 'name')
-          expect(result).to eq Addressable::Template.new('http://example.com/resources{?description,name}')
+        it "matches matching URIs" do
+          result = uri.attach_variables("description", "name")
+          expect(result).to eq Addressable::Template.new("http://example.com/resources{?description,name}")
         end
       end
     end
 
-    context 'when the URI contained variables' do
-      let(:original_template) { Addressable::Template.new('http://example.com/resources{/id}{?decorated}') }
-      let(:result) { original_template.attach_variables('expanded') }
+    context "when the URI contained variables" do
+      let(:original_template) { Addressable::Template.new("http://example.com/resources{/id}{?decorated}") }
+      let(:result) { original_template.attach_variables("expanded") }
 
-      it 'maintains the original variables' do
-        expect(result.variables).to include 'id'
-        expect(result.variables).to include 'decorated'
+      it "maintains the original variables" do
+        expect(result.variables).to include "id"
+        expect(result.variables).to include "decorated"
       end
 
-      it 'attaches the new variables' do
-        expect(result.variables).to include 'expanded'
-        expect(result.pattern).to eq 'http://example.com/resources{/id}{?decorated,expanded}'
+      it "attaches the new variables" do
+        expect(result.variables).to include "expanded"
+        expect(result.pattern).to eq "http://example.com/resources{/id}{?decorated,expanded}"
       end
 
-      it 'allows you to expand both previous and new variables' do
+      it "allows you to expand both previous and new variables" do
         expect(result.partial_expand(id: 3, decorated: true).pattern)
-          .to eq 'http://example.com/resources/3?decorated=true{&expanded}'
+          .to eq "http://example.com/resources/3?decorated=true{&expanded}"
       end
 
-      context 'when the last variable is part of the URI' do
-        let(:original_template) { Addressable::Template.new('http://example.com/resources{/id}') }
+      context "when the last variable is part of the URI" do
+        let(:original_template) { Addressable::Template.new("http://example.com/resources{/id}") }
 
-        it 'attaches the new variables' do
-          expect(result.variables).to include 'expanded'
-          expect(result.pattern).to eq 'http://example.com/resources{/id}{?expanded}'
+        it "attaches the new variables" do
+          expect(result.variables).to include "expanded"
+          expect(result.pattern).to eq "http://example.com/resources{/id}{?expanded}"
         end
       end
 
-      context 'when the URI was partially expanded' do
-        context 'with a trailing param' do
+      context "when the URI was partially expanded" do
+        context "with a trailing param" do
           let(:original_template) do
-            Addressable::Template.new('http://example.com/resources{/id}{?decorated,translated,additional}')
-              .partial_expand(id: 14, decorated: true, translated: 'es')
+            Addressable::Template.new("http://example.com/resources{/id}{?decorated,translated,additional}")
+              .partial_expand(id: 14, decorated: true, translated: "es")
           end
 
-          it 'attaches the new variables' do
-            expect(result.variables).to include 'expanded'
-            expect(result.pattern).to eq 'http://example.com/resources/14?decorated=true&translated=es{&additional,expanded}'
+          it "attaches the new variables" do
+            expect(result.variables).to include "expanded"
+            expect(result.pattern).to eq "http://example.com/resources/14?decorated=true&translated=es{&additional,expanded}"
           end
         end
 
-        context 'without trailing params' do
+        context "without trailing params" do
           let(:original_template) do
-            Addressable::Template.new('http://example.com/resources{/id}{?decorated}')
+            Addressable::Template.new("http://example.com/resources{/id}{?decorated}")
               .partial_expand(id: 14, decorated: true)
           end
 
-          it 'attaches the new variables' do
-            expect(result.variables).to include 'expanded'
-            expect(result.pattern).to eq 'http://example.com/resources/14?decorated=true{&expanded}'
+          it "attaches the new variables" do
+            expect(result.variables).to include "expanded"
+            expect(result.pattern).to eq "http://example.com/resources/14?decorated=true{&expanded}"
           end
         end
       end

--- a/spec/addressable/template_spec.rb
+++ b/spec/addressable/template_spec.rb
@@ -1344,6 +1344,101 @@ describe Addressable::Template do
       end
     end
   end
+
+  describe 'Adding variables' do
+    context 'when the URI did not contain them' do
+      let(:uri) { Addressable::Template.new('http://example.com/resources') }
+
+      context 'a single variable' do
+        it 'represents the variable' do
+          result = uri.attach_variables('description')
+          expect(result.pattern).to eq 'http://example.com/resources{?description}'
+        end
+
+        context 'when it is invalid' do
+          it 'raises an error' do
+            expect { uri.attach_variables('%invalid') }.to raise_error(Addressable::Template::NotAVariableError)
+          end
+        end
+      end
+
+      context 'multiple variables' do
+        it 'can partially expand the variable' do
+          result = uri.attach_variables('description', 'name')
+          expect(result.pattern).to eq 'http://example.com/resources{?description,name}'
+          result = result.attach_variables('last_name')
+          expect(result.pattern).to eq 'http://example.com/resources{?description,name,last_name}'
+        end
+
+        context 'when one of them is invalid' do
+          subject(:attach_invalid) { -> { uri.attach_variables('valid_var', '%invalid') } }
+          it { is_expected.to raise_error(Addressable::Template::NotAVariableError) }
+          it { is_expected.to raise_error(/%invalid/) }
+          it { is_expected.not_to raise_error(/valid_var/) }
+        end
+
+        it 'matches matching URIs' do
+          result = uri.attach_variables('description', 'name')
+          expect(result).to eq Addressable::Template.new('http://example.com/resources{?description,name}')
+        end
+      end
+    end
+
+    context 'when the URI contained variables' do
+      let(:original_template) { Addressable::Template.new('http://example.com/resources{/id}{?decorated}') }
+      let(:result) { original_template.attach_variables('expanded') }
+
+      it 'maintains the original variables' do
+        expect(result.variables).to include 'id'
+        expect(result.variables).to include 'decorated'
+      end
+
+      it 'attaches the new variables' do
+        expect(result.variables).to include 'expanded'
+        expect(result.pattern).to eq 'http://example.com/resources{/id}{?decorated,expanded}'
+      end
+
+      it 'allows you to expand both previous and new variables' do
+        expect(result.partial_expand(id: 3, decorated: true).pattern)
+          .to eq 'http://example.com/resources/3?decorated=true{&expanded}'
+      end
+
+      context 'when the last variable is part of the URI' do
+        let(:original_template) { Addressable::Template.new('http://example.com/resources{/id}') }
+
+        it 'attaches the new variables' do
+          expect(result.variables).to include 'expanded'
+          expect(result.pattern).to eq 'http://example.com/resources{/id}{?expanded}'
+        end
+      end
+
+      context 'when the URI was partially expanded' do
+        context 'with a trailing param' do
+          let(:original_template) do
+            Addressable::Template.new('http://example.com/resources{/id}{?decorated,translated,additional}')
+              .partial_expand(id: 14, decorated: true, translated: 'es')
+          end
+
+          it 'attaches the new variables' do
+            expect(result.variables).to include 'expanded'
+            expect(result.pattern).to eq 'http://example.com/resources/14?decorated=true&translated=es{&additional,expanded}'
+          end
+        end
+
+        context 'without trailing params' do
+          let(:original_template) do
+            Addressable::Template.new('http://example.com/resources{/id}{?decorated}')
+              .partial_expand(id: 14, decorated: true)
+          end
+
+          it 'attaches the new variables' do
+            expect(result.variables).to include 'expanded'
+            expect(result.pattern).to eq 'http://example.com/resources/14?decorated=true{&expanded}'
+          end
+        end
+      end
+    end
+  end
 end
 
 describe Addressable::Template::MatchData do


### PR DESCRIPTION
Use case:
I have a template that generally describes an endpoint. Under certain circumstances (say, the right permissions), the endpoint accepts additional attributes. When that's the case I'd like to be able to add the additional attributes without having to create a new template for every instance.

Happy to resolve any issues, code style, or anything I've missed.