### PR TITLE
Reduce object allocations in URI.encode_component and URI.normalize_component

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -412,7 +412,7 @@ module Addressable
       if upcase_encoded.length > 0
         component = component.gsub(/%(#{upcase_encoded.chars.map do |char|
           SEQUENCE_ENCODING_TABLE[char]
-        end.join('|')})/i) { |s| s.upcase }
+        end.join('|')})/) { |s| s.upcase }
       end
       return component
     end

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -410,9 +410,11 @@ module Addressable
         SEQUENCE_UPCASED_PERCENT_ENCODING_TABLE[sequence]
       end
       if upcase_encoded.length > 0
-        component = component.gsub(/%(#{upcase_encoded.chars.map do |char|
+        upcase_encoded_chars = upcase_encoded.chars.map do |char|
           SEQUENCE_ENCODING_TABLE[char]
-        end.join('|')})/) { |s| s.upcase }
+        end
+        component = component.gsub(/%(#{upcase_encoded_chars.join('|')})/,
+                                   &:upcase)
       end
       return component
     end

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -337,8 +337,8 @@ module Addressable
 
     SEQUENCE_UPCASED_PERCENT_ENCODING_TABLE = Hash.new do |hash, sequence|
       hash[sequence] = sequence.unpack("C*").map do |c|
-        format("%%%02x", c)
-      end.join.upcase
+        format("%%%02X", c)
+      end.join
     end
 
     ##


### PR DESCRIPTION
This PR optimizes object allocations when encoding URI components using a Hash as a cache.

For example, the [following code](https://github.com/sporkmonger/addressable/blob/d91a98d3af455fa14b2eef5da6266770fc524fe4/lib/addressable/uri.rb#L394-L396) runs everytime `URI.encode_component` is invoked (which is a lot of times in our application code):
```ruby
      component = component.gsub(character_class) do |sequence|
        (sequence.unpack('C*').map { |c| "%" + ("%02x" % c).upcase }).join
      end
```

For each character in "character_class" (a regexp which matches around 20 different single characters):
 - an Array is allocated by `unpack`
 - then another Array by `map`
 - plus for each integer returned by the `unpack`, allocates two strings (one format string which is then upcased)
 - and finally a string by `join`

We implemented a cache using `Hash.new(&block)` which eliminates all the object allocations in the above code after the first time the `URI.encode_component` is invoked.

The following stackprof trace shows how important this optimization is to us since 20% of object allocations in our programs were done in the above loop:
```
bash-4.2$  bundle exec stackprof stackprof-no-km-no-rm.dump --text --limit 10 --method Addressable::URI.encode_component
Addressable::URI.encode_component (/opt/app-root/src/.bundle/ruby/2.4.0/gems/addressable-2.5.2/lib/addressable/uri.rb:355)
  samples:  2253710 self (24.3%)  /   2253710 total (24.3%)
  callers:
    3126938  (  138.7%)  Addressable::URI.encode_component
    2248646  (   99.8%)  Addressable::URI.form_encode
    5064  (    0.2%)  Addressable::URI.normalize_component
  callees (0 total):
    3126938  (    Inf%)  Addressable::URI.encode_component
  code:
                                  |   355  |     def self.encode_component(component, character_class=
                                  |   356  |         CharacterClasses::RESERVED + CharacterClasses::UNRESERVED,
 4372    (0.0%) /  4372   (0.0%)  |   357  |         upcase_encoded='')
                                  |   358  |       return nil if component.nil?
                                  |   359  | 
                                  |   360  |       begin
                                  |   361  |         if component.kind_of?(Symbol) ||
                                  |   362  |             component.kind_of?(Numeric) ||
                                  |   363  |             component.kind_of?(TrueClass) ||
                                  |   364  |             component.kind_of?(FalseClass)
                                  |   365  |           component = component.to_s
                                  |   366  |         else
                                  |   367  |           component = component.to_str
                                  |   368  |         end
                                  |   369  |       rescue TypeError, NoMethodError
                                  |   370  |         raise TypeError, "Can't convert #{component.class} into String."
                                  |   371  |       end if !component.is_a? String
                                  |   372  | 
 5638    (0.1%) /  5638   (0.1%)  |   373  |       if ![String, Regexp].include?(character_class.class)
                                  |   374  |         raise TypeError,
                                  |   375  |           "Expected String or Regexp, got #{character_class.inspect}"
                                  |   376  |       end
                                  |   377  |       if character_class.kind_of?(String)
 35014    (0.4%) /  35014   (0.4%)  |   378  |         character_class = /[^#{character_class}]/
                                  |   379  |       end
                                  |   380  |       # We can't perform regexps on invalid UTF sequences, but
                                  |   381  |       # here we need to, so switch to ASCII.
 6368    (0.1%) /  6368   (0.1%)  |   382  |       component = component.dup
                                  |   383  |       component.force_encoding(Encoding::ASCII_8BIT)
                                  |   384  |       # Avoiding gsub! because there are edge cases with frozen strings
 2202318   (23.8%) /  326156   (3.5%)  |   385  |       component = component.gsub(character_class) do |sequence|
 3126938   (33.8%) /  1876162  (20.3%)  |   386  |         (sequence.unpack('C*').map { |c| "%" + ("%02x" % c).upcase }).join
                                  |   387  |       end
```