### PR TITLE
Use host when setting TLD

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1182,7 +1182,7 @@ module Addressable
     #
     # @param [String, #to_str] new_tld The new top-level domain.
     def tld=(new_tld)
-      replaced_tld = domain.sub(/#{tld}\z/, new_tld)
+      replaced_tld = host.sub(/#{tld}\z/, new_tld)
       self.host = PublicSuffix::Domain.new(replaced_tld).to_s
     end
 

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -5515,18 +5515,18 @@ describe Addressable::URI, "when given the tld " do
   end
 
   context "which " do
-    let (:uri) { Addressable::URI.parse("http://comrade.net/path/to/source/") }
+    let (:uri) { Addressable::URI.parse("http://www.comrade.net/path/to/source/") }
 
     it "contains a subdomain" do
       uri.tld = "co.uk"
 
-      expect(uri.to_s).to eq("http://comrade.co.uk/path/to/source/")
+      expect(uri.to_s).to eq("http://www.comrade.co.uk/path/to/source/")
     end
 
     it "is part of the domain" do
       uri.tld = "com"
 
-      expect(uri.to_s).to eq("http://comrade.com/path/to/source/")
+      expect(uri.to_s).to eq("http://www.comrade.com/path/to/source/")
     end
   end
 end


### PR DESCRIPTION
## Problem

When setting the TLD the subdomains are lost:
```
$ a = Addressable::URI.parse('http://www.example.com')
=> #<Addressable::URI:0x3ff0f9992c24 URI:http://www.example.com>
$ a.tld = 'co.uk'
=> "co.uk"
$ a
=> #<Addressable::URI:0x3ff0f9992c24 URI:http://example.co.uk>
```

This issue is raised here: https://github.com/sporkmonger/addressable/issues/338

## Solution

The solution is to use the `host` instead of the `domain` when setting the TLD.