### PR TITLE
CI: Update matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,21 @@ cache: bundler
 language: ruby
 rvm:
   - jruby-9.0.5.0
-  - jruby-9.1.16.0
-  - jruby-9.2.5.0
+  - jruby-9.1.17.0
+  - jruby-9.2.6.0
   - ruby-head
   - ruby-head-clang
   - 2.0.0
   - 2.1.10
   - 2.2.10
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2
 matrix:
   include:
     - gemfile: gemfiles/Gemfile.public_suffix_2
-      rvm: 2.5.0
+      rvm: 2.5.5
   allow_failures:
     - rvm: ruby-head
     - rvm: ruby-head-clang
@@ -26,4 +26,3 @@ before_install:
   - gem update bundler
 #   - apt-get update
 #   - apt-get install idn
-sudo: false


### PR DESCRIPTION
This PR updates the CI matrix to the latest versions.

  - Also: Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration