### PR TITLE
Check if calling force_encoding is necessary before doing so in Addressable::URI, replace with encode! where applicable

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -552,7 +552,7 @@ module Addressable
       rescue ArgumentError
         encoded = self.encode_component(unencoded)
       end
-      encoded.force_encoding(Encoding::UTF_8)
+      encoded.encode!(Encoding::UTF_8, invalid: :replace, replace: "")
       return encoded
     end
 
@@ -865,7 +865,9 @@ module Addressable
         end
       end
       # All normalized values should be UTF-8
-      @normalized_scheme.force_encoding(Encoding::UTF_8) if @normalized_scheme
+      if @normalized_scheme && @normalized_scheme.encoding != Encoding::UTF_8
+        @normalized_scheme.encode!(Encoding::UTF_8, invalid: :replace, replace: "")
+      end
       @normalized_scheme
     end
 
@@ -920,7 +922,9 @@ module Addressable
         end
       end
       # All normalized values should be UTF-8
-      @normalized_user.force_encoding(Encoding::UTF_8) if @normalized_user
+      if @normalized_user && @normalized_user.encoding != Encoding::UTF_8
+        @normalized_user.encode!(Encoding::UTF_8, invalid: :replace, replace: "")
+      end
       @normalized_user
     end
 
@@ -977,8 +981,8 @@ module Addressable
         end
       end
       # All normalized values should be UTF-8
-      if @normalized_password
-        @normalized_password.force_encoding(Encoding::UTF_8)
+      if @normalized_password && @normalized_password.encoding != Encoding::UTF_8
+        @normalized_password.encode!(Encoding::UTF_8, invalid: :replace, replace: "")
       end
       @normalized_password
     end
@@ -1047,8 +1051,8 @@ module Addressable
         end
       end
       # All normalized values should be UTF-8
-      if @normalized_userinfo
-        @normalized_userinfo.force_encoding(Encoding::UTF_8)
+      if @normalized_userinfo && @normalized_userinfo.encoding != Encoding::UTF_8
+        @normalized_userinfo.encode!(Encoding::UTF_8, invalid: :replace, replace: "")
       end
       @normalized_userinfo
     end
@@ -1114,7 +1118,9 @@ module Addressable
         end
       end
       # All normalized values should be UTF-8
-      @normalized_host.force_encoding(Encoding::UTF_8) if @normalized_host
+      if @normalized_host && @normalized_host.encoding != Encoding::UTF_8
+        @normalized_host.encode!(Encoding::UTF_8, invalid: :replace, replace: "")
+      end
       @normalized_host
     end
 
@@ -1232,8 +1238,8 @@ module Addressable
         authority
       end
       # All normalized values should be UTF-8
-      if @normalized_authority
-        @normalized_authority.force_encoding(Encoding::UTF_8)
+      if @normalized_authority && @normalized_authority.encoding != Encoding::UTF_8
+        @normalized_authority.encode!(Encoding::UTF_8, invalid: :replace, replace: "")
       end
       @normalized_authority
     end
@@ -1468,7 +1474,9 @@ module Addressable
         site_string
       end
       # All normalized values should be UTF-8
-      @normalized_site.force_encoding(Encoding::UTF_8) if @normalized_site
+      if @normalized_site && @normalized_site.encoding != Encoding::UTF_8
+        @normalized_site.encode!(Encoding::UTF_8, invalid: :replace, replace: "")
+      end
       @normalized_site
     end
 
@@ -1531,7 +1539,9 @@ module Addressable
         result
       end
       # All normalized values should be UTF-8
-      @normalized_path.force_encoding(Encoding::UTF_8) if @normalized_path
+      if @normalized_path && @normalized_path.encoding != Encoding::UTF_8
+         @normalized_path.encode!(Encoding::UTF_8, invalid: :replace, replace: "")
+      end
       @normalized_path
     end
 
@@ -1602,7 +1612,9 @@ module Addressable
         component == "" ? nil : component
       end
       # All normalized values should be UTF-8
-      @normalized_query.force_encoding(Encoding::UTF_8) if @normalized_query
+      if @normalized_query && @normalized_query.encoding != Encoding::UTF_8
+        @normalized_query.encode!(Encoding::UTF_8, invalid: :replace, replace: "")
+      end
       @normalized_query
     end
 
@@ -1796,8 +1808,8 @@ module Addressable
         component == "" ? nil : component
       end
       # All normalized values should be UTF-8
-      if @normalized_fragment
-        @normalized_fragment.force_encoding(Encoding::UTF_8)
+      if @normalized_fragment && @normalized_fragment.encoding != Encoding::UTF_8
+        @normalized_fragment.encode!(Encoding::UTF_8, invalid: :replace, replace: "")
       end
       @normalized_fragment
     end
@@ -2325,7 +2337,7 @@ module Addressable
         uri_string << self.path.to_s
         uri_string << "?#{self.query}" if self.query != nil
         uri_string << "##{self.fragment}" if self.fragment != nil
-        uri_string.force_encoding(Encoding::UTF_8)
+        uri_string.encode!(Encoding::UTF_8, invalid: :replace, replace: "")
         uri_string
       end
     end


### PR DESCRIPTION
The first commit is a quick fix to [this issue](https://github.com/sporkmonger/addressable/issues/254), just adding in an extra check to avoid mutating strings when it isn't necessary. The second sets up handling for the off chance that the normalization process doesn't succeed at removing all of the utf-8 invalid characters. `force_encoding` just changes what the string reports its encoding is, using `str.encode!(Encoding::UTF_8, invalid: :replace, replace: "")` will change the coding and replace any invalid bytes with an empty string. It's possibly not strictly necessary, but it does seem to be the intent of forcing the encoding throughout this file.