### PR TITLE
Check Encodings before calling force_encoding in Addressable::URI

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -900,7 +900,9 @@ module Addressable
         end
       end
       # All normalized values should be UTF-8
-      @normalized_scheme.force_encoding(Encoding::UTF_8) if @normalized_scheme
+      if @normalized_scheme && @normalized_scheme.encoding != Encoding::UTF_8
+        @normalized_scheme.force_encoding(Encoding::UTF_8)
+      end
       @normalized_scheme
     end
 
@@ -955,7 +957,9 @@ module Addressable
         end
       end
       # All normalized values should be UTF-8
-      @normalized_user.force_encoding(Encoding::UTF_8) if @normalized_user
+      if @normalized_user && @normalized_user.encoding != Encoding::UTF_8
+        @normalized_user.force_encoding(Encoding::UTF_8)
+      end
       @normalized_user
     end
 
@@ -1012,7 +1016,9 @@ module Addressable
         end
       end
       # All normalized values should be UTF-8
-      if @normalized_password
+      if @normalized_password && (
+        @normalized_password.encoding != Encoding::UTF_8
+      )
         @normalized_password.force_encoding(Encoding::UTF_8)
       end
       @normalized_password
@@ -1082,7 +1088,9 @@ module Addressable
         end
       end
       # All normalized values should be UTF-8
-      if @normalized_userinfo
+      if @normalized_userinfo && (
+        @normalized_userinfo.encoding != Encoding::UTF_8
+      )
         @normalized_userinfo.force_encoding(Encoding::UTF_8)
       end
       @normalized_userinfo
@@ -1151,7 +1159,7 @@ module Addressable
         end
       end
       # All normalized values should be UTF-8
-      if @normalized_host && !@normalized_host.empty?
+      if @normalized_host && @normalized_host.encoding != Encoding::UTF_8
         @normalized_host.force_encoding(Encoding::UTF_8)
       end
       @normalized_host
@@ -1271,7 +1279,9 @@ module Addressable
         authority
       end
       # All normalized values should be UTF-8
-      if @normalized_authority
+      if @normalized_authority && (
+        @normalized_authority.encoding != Encoding::UTF_8
+      )
         @normalized_authority.force_encoding(Encoding::UTF_8)
       end
       @normalized_authority
@@ -1507,7 +1517,9 @@ module Addressable
         site_string
       end
       # All normalized values should be UTF-8
-      @normalized_site.force_encoding(Encoding::UTF_8) if @normalized_site
+      if @normalized_site && @normalized_site.encoding != Encoding::UTF_8
+        @normalized_site.force_encoding(Encoding::UTF_8)
+      end
       @normalized_site
     end
 
@@ -1570,7 +1582,9 @@ module Addressable
         result
       end
       # All normalized values should be UTF-8
-      @normalized_path.force_encoding(Encoding::UTF_8) if @normalized_path
+      if @normalized_path && @normalized_path.encoding != Encoding::UTF_8
+         @normalized_path.force_encoding(Encoding::UTF_8)
+      end
       @normalized_path
     end
 
@@ -1646,7 +1660,9 @@ module Addressable
         component == "" ? nil : component
       end
       # All normalized values should be UTF-8
-      @normalized_query.force_encoding(Encoding::UTF_8) if @normalized_query
+      if @normalized_query && @normalized_query.encoding != Encoding::UTF_8
+        @normalized_query.force_encoding(Encoding::UTF_8)
+      end
       @normalized_query
     end
 
@@ -1842,7 +1858,9 @@ module Addressable
         component == "" ? nil : component
       end
       # All normalized values should be UTF-8
-      if @normalized_fragment
+      if @normalized_fragment && (
+        @normalized_fragment.encoding != Encoding::UTF_8
+      )
         @normalized_fragment.force_encoding(Encoding::UTF_8)
       end
       @normalized_fragment

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -900,9 +900,7 @@ module Addressable
         end
       end
       # All normalized values should be UTF-8
-      if @normalized_scheme && @normalized_scheme.encoding != Encoding::UTF_8
-        @normalized_scheme.force_encoding(Encoding::UTF_8)
-      end
+      force_utf8_encoding_if_needed(@normalized_scheme)
       @normalized_scheme
     end
 
@@ -957,9 +955,7 @@ module Addressable
         end
       end
       # All normalized values should be UTF-8
-      if @normalized_user && @normalized_user.encoding != Encoding::UTF_8
-        @normalized_user.force_encoding(Encoding::UTF_8)
-      end
+      force_utf8_encoding_if_needed(@normalized_user)
       @normalized_user
     end
 
@@ -1016,11 +1012,7 @@ module Addressable
         end
       end
       # All normalized values should be UTF-8
-      if @normalized_password && (
-        @normalized_password.encoding != Encoding::UTF_8
-      )
-        @normalized_password.force_encoding(Encoding::UTF_8)
-      end
+      force_utf8_encoding_if_needed(@normalized_password)
       @normalized_password
     end
 
@@ -1088,11 +1080,7 @@ module Addressable
         end
       end
       # All normalized values should be UTF-8
-      if @normalized_userinfo && (
-        @normalized_userinfo.encoding != Encoding::UTF_8
-      )
-        @normalized_userinfo.force_encoding(Encoding::UTF_8)
-      end
+      force_utf8_encoding_if_needed(@normalized_userinfo)
       @normalized_userinfo
     end
 
@@ -1159,9 +1147,7 @@ module Addressable
         end
       end
       # All normalized values should be UTF-8
-      if @normalized_host && @normalized_host.encoding != Encoding::UTF_8
-        @normalized_host.force_encoding(Encoding::UTF_8)
-      end
+      force_utf8_encoding_if_needed(@normalized_host)
       @normalized_host
     end
 
@@ -1279,11 +1265,7 @@ module Addressable
         authority
       end
       # All normalized values should be UTF-8
-      if @normalized_authority && (
-        @normalized_authority.encoding != Encoding::UTF_8
-      )
-        @normalized_authority.force_encoding(Encoding::UTF_8)
-      end
+      force_utf8_encoding_if_needed(@normalized_authority)
       @normalized_authority
     end
 
@@ -1517,9 +1499,7 @@ module Addressable
         site_string
       end
       # All normalized values should be UTF-8
-      if @normalized_site && @normalized_site.encoding != Encoding::UTF_8
-        @normalized_site.force_encoding(Encoding::UTF_8)
-      end
+      force_utf8_encoding_if_needed(@normalized_site)
       @normalized_site
     end
 
@@ -1582,9 +1562,7 @@ module Addressable
         result
       end
       # All normalized values should be UTF-8
-      if @normalized_path && @normalized_path.encoding != Encoding::UTF_8
-         @normalized_path.force_encoding(Encoding::UTF_8)
-      end
+      force_utf8_encoding_if_needed(@normalized_path)
       @normalized_path
     end
 
@@ -1660,9 +1638,7 @@ module Addressable
         component == "" ? nil : component
       end
       # All normalized values should be UTF-8
-      if @normalized_query && @normalized_query.encoding != Encoding::UTF_8
-        @normalized_query.force_encoding(Encoding::UTF_8)
-      end
+      force_utf8_encoding_if_needed(@normalized_query)
       @normalized_query
     end
 
@@ -1858,11 +1834,7 @@ module Addressable
         component == "" ? nil : component
       end
       # All normalized values should be UTF-8
-      if @normalized_fragment && (
-        @normalized_fragment.encoding != Encoding::UTF_8
-      )
-        @normalized_fragment.force_encoding(Encoding::UTF_8)
-      end
+      force_utf8_encoding_if_needed(@normalized_fragment)
       @normalized_fragment
     end
 
@@ -2569,6 +2541,16 @@ module Addressable
     def remove_composite_values
       remove_instance_variable(:@uri_string) if defined?(@uri_string)
       remove_instance_variable(:@hash) if defined?(@hash)
+    end
+
+    ##
+    # Converts the string to be UTF-8 if it is not already UTF-8
+    #
+    # @api private
+    def force_utf8_encoding_if_needed(str)
+      if str && str.encoding != Encoding::UTF_8
+        str.force_encoding(Encoding::UTF_8)
+      end
     end
   end
 end

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -1060,9 +1060,7 @@ describe Addressable::URI, "when normalized and then deeply frozen" do
   end
 
   it "should not allow destructive operations" do
-    ruby_check = Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5.0")
-    error = ruby_check ? RuntimeError : FrozenError
-    expect { @uri.normalize! }.to raise_error(error)
+    expect { @uri.normalize! }.to raise_error(RuntimeError)
   end
 end
 

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -1061,7 +1061,9 @@ describe Addressable::URI, "when normalized and then deeply frozen" do
   end
 
   it "should not allow destructive operations" do
-    expect { @uri.normalize! }.to raise_error(FrozenError)
+    ruby_check = Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5.0")
+    error = ruby_check ? RuntimeError : FrozenError
+    expect { @uri.normalize! }.to raise_error(error)
   end
 end
 

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -999,6 +999,72 @@ describe Addressable::URI, "when frozen" do
   end
 end
 
+describe Addressable::URI, "when normalized and then deeply frozen" do
+  before do
+    @uri = Addressable::URI.parse(
+      "http://user:password@example.com:8080/path?query=value#fragment"
+    ).normalize!
+
+    @uri.instance_variables.each do |var|
+      @uri.instance_variable_set(var, @uri.instance_variable_get(var).freeze)
+    end
+
+    @uri.freeze
+  end
+
+  it "#normalized_scheme should not error" do
+    expect { @uri.normalized_scheme }.not_to raise_error
+  end
+
+  it "#normalized_user should not error" do
+    expect { @uri.normalized_user }.not_to raise_error
+  end
+
+  it "#normalized_password should not error" do
+    expect { @uri.normalized_password }.not_to raise_error
+  end
+
+  it "#normalized_userinfo should not error" do
+    expect { @uri.normalized_userinfo }.not_to raise_error
+  end
+
+  it "#normalized_host should not error" do
+    expect { @uri.normalized_host }.not_to raise_error
+  end
+
+  it "#normalized_authority should not error" do
+    expect { @uri.normalized_authority }.not_to raise_error
+  end
+
+  it "#normalized_port should not error" do
+    expect { @uri.normalized_port }.not_to raise_error
+  end
+
+  it "#normalized_site should not error" do
+    expect { @uri.normalized_site }.not_to raise_error
+  end
+
+  it "#normalized_path should not error" do
+    expect { @uri.normalized_path }.not_to raise_error
+  end
+
+  it "#normalized_query should not error" do
+    expect { @uri.normalized_query }.not_to raise_error
+  end
+
+  it "#normalized_fragment should not error" do
+    expect { @uri.normalized_fragment }.not_to raise_error
+  end
+
+  it "should be frozen" do
+    expect(@uri).to be_frozen
+  end
+
+  it "should not allow destructive operations" do
+    expect { @uri.normalize! }.to raise_error(FrozenError)
+  end
+end
+
 describe Addressable::URI, "when created from string components" do
   before do
     @uri = Addressable::URI.new(


### PR DESCRIPTION
Reopening [this pr](https://github.com/sporkmonger/addressable/pull/340) with just the minimum changes to fix the issue blocking our use of the current version.

This is a quick fix to [this issue](https://github.com/sporkmonger/addressable/issues/254), just adding in an extra check to avoid mutating strings when it isn't necessary

Close #254