### PR TITLE
Iterate with #each to reduce array allocations

### DIFF
--- a/lib/addressable/idna/pure.rb
+++ b/lib/addressable/idna/pure.rb
@@ -341,7 +341,7 @@ module Addressable
     end
 
     COMPOSITION_TABLE = {}
-    for codepoint, data in UNICODE_DATA
+    UNICODE_DATA.each do |codepoint, data|
       canonical = data[UNICODE_DATA_CANONICAL]
       exclusion = data[UNICODE_DATA_EXCLUSION]
 


### PR DESCRIPTION
To confirm you may use the following script and manually compare between `master` and this PR:
```ruby
# frozen_string_literal: true

require "memory_profiler"
require "bundler/setup"

report = MemoryProfiler.report(trace: Array) { require "addressable/uri" }
report.pretty_print(to_file: ".memprof.tmp", scale_bytes: true)
```
Local tests at my end show the following results:
### Before
```
Total allocated: 1.04 MB (17860 objects)
Total retained:  529.93 kB (5158 objects)

allocated memory by class
-----------------------------------
   1.04 MB  Array
```
### After
```
Total allocated: 530.21 kB (5161 objects)
Total retained:  529.93 kB (5158 objects)

allocated memory by class
-----------------------------------
 530.21 kB  Array
```

