### PR TITLE
Add :compacted option to URI#normalized_query

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1595,6 +1595,7 @@ module Addressable
         # Make sure possible key-value pair delimiters are escaped.
         modified_query_class.sub!("\\&", "").sub!("\\;", "")
         pairs = (self.query || "").split("&", -1)
+        pairs.delete_if(&:empty?) if flags.include?(:compacted)
         pairs.sort! if flags.include?(:sorted)
         component = pairs.map do |pair|
           Addressable::URI.normalize_component(pair, modified_query_class, "+")

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -4303,6 +4303,26 @@ describe Addressable::URI, "when parsed from " +
   end
 end
 
+describe Addressable::URI, "when parsed from 'http://example/?b=1&a=2&c=3'" do
+  before do
+    @uri = Addressable::URI.parse("http://example/?b=1&a=2&c=3")
+  end
+
+  it "should have a sorted normalized query of 'a=2&b=1&c=3'" do
+    expect(@uri.normalized_query(:sorted)).to eq("a=2&b=1&c=3")
+  end
+end
+
+describe Addressable::URI, "when parsed from 'http://example/?&a&&c&'" do
+  before do
+    @uri = Addressable::URI.parse("http://example/?&a&&c&")
+  end
+
+  it "should have a compacted normalized query of 'a&c'" do
+    expect(@uri.normalized_query(:compacted)).to eq("a&c")
+  end
+end
+
 describe Addressable::URI, "when parsed from " +
     "'http://example.com/sound%2bvision'" do
   before do


### PR DESCRIPTION
This option removes empty parameters, having no name or value.