### PR TITLE
Update public suffix gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ doc
 heckling
 pkg
 specdoc
+vendor/

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'rspec', '~> 3.5'
-  gem 'rspec-its', '~> 1.1'
+  gem 'rspec', '~> 3.8'
+  gem 'rspec-its', '~> 1.3'
 end
 
 group :development do

--- a/addressable.gemspec
+++ b/addressable.gemspec
@@ -24,14 +24,14 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<public_suffix>, ["< 4.0", ">= 2.0.2"])
+      s.add_runtime_dependency(%q<public_suffix>, ["< 5.0", ">= 2.0.2"])
       s.add_development_dependency(%q<bundler>, ["< 3.0", ">= 1.0"])
     else
-      s.add_dependency(%q<public_suffix>, ["< 4.0", ">= 2.0.2"])
+      s.add_dependency(%q<public_suffix>, ["< 5.0", ">= 2.0.2"])
       s.add_dependency(%q<bundler>, ["< 3.0", ">= 1.0"])
     end
   else
-    s.add_dependency(%q<public_suffix>, ["< 4.0", ">= 2.0.2"])
+    s.add_dependency(%q<public_suffix>, ["< 5.0", ">= 2.0.2"])
     s.add_dependency(%q<bundler>, ["< 3.0", ">= 1.0"])
   end
 

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -3944,7 +3944,7 @@ describe Addressable::URI, "when parsed from " +
   it "should raise an error if assigning a bogus object to the hostname" do
     expect(lambda do
       @uri.hostname = Object.new
-    end).to raise_error
+    end).to raise_error(TypeError)
   end
 
   it "should have the correct port after assignment" do
@@ -4417,7 +4417,7 @@ describe Addressable::URI, "when parsed from " +
     expect(lambda do
       # This would create an invalid URI
       @uri.authority = nil
-    end).to raise_error
+    end).to raise_error(Addressable::URI::InvalidURIError)
   end
 end
 
@@ -4820,7 +4820,7 @@ describe Addressable::URI, "when parsed from '?one=1&two=2&three=3'" do
 
   it "should raise an error for invalid return type values" do
     expect(lambda do
-      @uri.query_values(Fixnum)
+      @uri.query_values(Integer)
     end).to raise_error(ArgumentError)
   end
 


### PR DESCRIPTION
This PR allows to update `public_suffix` gem to version 4.0.1.

In addition, the warnings that appear when running the specs has been solved.