### PR TITLE
Only include the key files in the gem artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ heckling
 pkg
 specdoc
 vendor/
+*.gem

--- a/addressable.gemspec
+++ b/addressable.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = "Addressable is an alternative implementation to the URI implementation that is\npart of Ruby's standard library. It is flexible, offers heuristic parsing, and\nadditionally provides extensive support for IRIs and URI templates.\n".freeze
   s.email = "bob@sporkmonger.com".freeze
   s.extra_rdoc_files = ["README.md".freeze]
-  s.files = ["CHANGELOG.md".freeze, "Gemfile".freeze, "LICENSE.txt".freeze, "README.md".freeze, "Rakefile".freeze, "data/unicode.data".freeze, "lib/addressable".freeze, "lib/addressable.rb".freeze, "lib/addressable/idna".freeze, "lib/addressable/idna.rb".freeze, "lib/addressable/idna/native.rb".freeze, "lib/addressable/idna/pure.rb".freeze, "lib/addressable/template.rb".freeze, "lib/addressable/uri.rb".freeze, "lib/addressable/version.rb".freeze, "spec/addressable".freeze, "spec/addressable/idna_spec.rb".freeze, "spec/addressable/net_http_compat_spec.rb".freeze, "spec/addressable/rack_mount_compat_spec.rb".freeze, "spec/addressable/security_spec.rb".freeze, "spec/addressable/template_spec.rb".freeze, "spec/addressable/uri_spec.rb".freeze, "spec/spec_helper.rb".freeze, "tasks/clobber.rake".freeze, "tasks/gem.rake".freeze, "tasks/git.rake".freeze, "tasks/metrics.rake".freeze, "tasks/rspec.rake".freeze, "tasks/yard.rake".freeze]
+  s.files = Dir.glob("{lib,data}/**/*") + ["LICENSE.txt".freeze, "CHANGELOG.md".freeze, "README.md".freeze]
   s.homepage = "https://github.com/sporkmonger/addressable".freeze
   s.licenses = ["Apache-2.0".freeze]
   s.rdoc_options = ["--main".freeze, "README.md".freeze]


### PR DESCRIPTION
This change ships just the necessary files for the gem + the license,
changelog and readme. This avoids shipping things like the specs and
rake tasks. It cuts the size of the gem artifact by 25%+ and reduces
file count on disk significantly which improves performance on windows
hosts as they have to AV scan each file written.

Signed-off-by: Tim Smith <tsmith@chef.io>