### PR TITLE
Freeze string literals

### DIFF
--- a/addressable.gemspec
+++ b/addressable.gemspec
@@ -13,13 +13,7 @@ Gem::Specification.new do |s|
   s.description = "Addressable is an alternative implementation to the URI implementation that is\npart of Ruby's standard library. It is flexible, offers heuristic parsing, and\nadditionally provides extensive support for IRIs and URI templates.\n"
   s.email = "bob@sporkmonger.com"
   s.extra_rdoc_files = ["README.md"]
-  s.files = [
-    "CHANGELOG.md", "Gemfile", "LICENSE.txt", "README.md", "Rakefile", "data/unicode.data", "lib/addressable", "lib/addressable.rb",
-    "lib/addressable/idna", "lib/addressable/idna.rb", "lib/addressable/idna/native.rb", "lib/addressable/idna/pure.rb", "lib/addressable/template.rb",
-    "lib/addressable/uri.rb", "lib/addressable/version.rb", "spec/addressable", "spec/addressable/idna_spec.rb", "spec/addressable/net_http_compat_spec.rb",
-    "spec/addressable/rack_mount_compat_spec.rb", "spec/addressable/security_spec.rb", "spec/addressable/template_spec.rb", "spec/addressable/uri_spec.rb",
-    "spec/spec_helper.rb", "tasks/clobber.rake", "tasks/gem.rake", "tasks/git.rake", "tasks/metrics.rake", "tasks/rspec.rake", "tasks/yard.rake"
-    ]
+  s.files = ["CHANGELOG.md", "Gemfile", "LICENSE.txt", "README.md", "Rakefile", "data/unicode.data", "lib/addressable", "lib/addressable.rb","lib/addressable/idna", "lib/addressable/idna.rb", "lib/addressable/idna/native.rb", "lib/addressable/idna/pure.rb", "lib/addressable/template.rb","lib/addressable/uri.rb", "lib/addressable/version.rb", "spec/addressable", "spec/addressable/idna_spec.rb", "spec/addressable/net_http_compat_spec.rb","spec/addressable/rack_mount_compat_spec.rb", "spec/addressable/security_spec.rb", "spec/addressable/template_spec.rb", "spec/addressable/uri_spec.rb","spec/spec_helper.rb", "tasks/clobber.rake", "tasks/gem.rake", "tasks/git.rake", "tasks/metrics.rake", "tasks/rspec.rake", "tasks/yard.rake"]
   s.homepage = "https://github.com/sporkmonger/addressable"
   s.licenses = ["Apache-2.0"]
   s.rdoc_options = ["--main", "README.md"]

--- a/addressable.gemspec
+++ b/addressable.gemspec
@@ -1,37 +1,44 @@
+# frozen_string_literal: true
 # -*- encoding: utf-8 -*-
 # stub: addressable 2.7.0 ruby lib
 
 Gem::Specification.new do |s|
-  s.name = "addressable".freeze
+  s.name = "addressable"
   s.version = "2.7.0"
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
-  s.require_paths = ["lib".freeze]
-  s.authors = ["Bob Aman".freeze]
+  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib"]
+  s.authors = ["Bob Aman"]
   s.date = "2019-08-31"
-  s.description = "Addressable is an alternative implementation to the URI implementation that is\npart of Ruby's standard library. It is flexible, offers heuristic parsing, and\nadditionally provides extensive support for IRIs and URI templates.\n".freeze
-  s.email = "bob@sporkmonger.com".freeze
-  s.extra_rdoc_files = ["README.md".freeze]
-  s.files = ["CHANGELOG.md".freeze, "Gemfile".freeze, "LICENSE.txt".freeze, "README.md".freeze, "Rakefile".freeze, "data/unicode.data".freeze, "lib/addressable".freeze, "lib/addressable.rb".freeze, "lib/addressable/idna".freeze, "lib/addressable/idna.rb".freeze, "lib/addressable/idna/native.rb".freeze, "lib/addressable/idna/pure.rb".freeze, "lib/addressable/template.rb".freeze, "lib/addressable/uri.rb".freeze, "lib/addressable/version.rb".freeze, "spec/addressable".freeze, "spec/addressable/idna_spec.rb".freeze, "spec/addressable/net_http_compat_spec.rb".freeze, "spec/addressable/rack_mount_compat_spec.rb".freeze, "spec/addressable/security_spec.rb".freeze, "spec/addressable/template_spec.rb".freeze, "spec/addressable/uri_spec.rb".freeze, "spec/spec_helper.rb".freeze, "tasks/clobber.rake".freeze, "tasks/gem.rake".freeze, "tasks/git.rake".freeze, "tasks/metrics.rake".freeze, "tasks/rspec.rake".freeze, "tasks/yard.rake".freeze]
-  s.homepage = "https://github.com/sporkmonger/addressable".freeze
-  s.licenses = ["Apache-2.0".freeze]
-  s.rdoc_options = ["--main".freeze, "README.md".freeze]
-  s.required_ruby_version = Gem::Requirement.new(">= 2.0".freeze)
-  s.rubygems_version = "2.5.2.3".freeze
-  s.summary = "URI Implementation".freeze
+  s.description = "Addressable is an alternative implementation to the URI implementation that is\npart of Ruby's standard library. It is flexible, offers heuristic parsing, and\nadditionally provides extensive support for IRIs and URI templates.\n"
+  s.email = "bob@sporkmonger.com"
+  s.extra_rdoc_files = ["README.md"]
+  s.files = [
+    "CHANGELOG.md", "Gemfile", "LICENSE.txt", "README.md", "Rakefile", "data/unicode.data", "lib/addressable", "lib/addressable.rb",
+    "lib/addressable/idna", "lib/addressable/idna.rb", "lib/addressable/idna/native.rb", "lib/addressable/idna/pure.rb", "lib/addressable/template.rb",
+    "lib/addressable/uri.rb", "lib/addressable/version.rb", "spec/addressable", "spec/addressable/idna_spec.rb", "spec/addressable/net_http_compat_spec.rb",
+    "spec/addressable/rack_mount_compat_spec.rb", "spec/addressable/security_spec.rb", "spec/addressable/template_spec.rb", "spec/addressable/uri_spec.rb",
+    "spec/spec_helper.rb", "tasks/clobber.rake", "tasks/gem.rake", "tasks/git.rake", "tasks/metrics.rake", "tasks/rspec.rake", "tasks/yard.rake"
+    ]
+  s.homepage = "https://github.com/sporkmonger/addressable"
+  s.licenses = ["Apache-2.0"]
+  s.rdoc_options = ["--main", "README.md"]
+  s.required_ruby_version = Gem::Requirement.new(">= 2.0")
+  s.rubygems_version = "2.5.2.3"
+  s.summary = "URI Implementation"
 
   if s.respond_to? :specification_version then
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<public_suffix>.freeze, ["< 5.0", ">= 2.0.2"])
-      s.add_development_dependency(%q<bundler>.freeze, ["< 3.0", ">= 1.0"])
+      s.add_runtime_dependency(%q<public_suffix>, ["< 5.0", ">= 2.0.2"])
+      s.add_development_dependency(%q<bundler>, ["< 3.0", ">= 1.0"])
     else
-      s.add_dependency(%q<public_suffix>.freeze, ["< 5.0", ">= 2.0.2"])
-      s.add_dependency(%q<bundler>.freeze, ["< 3.0", ">= 1.0"])
+      s.add_dependency(%q<public_suffix>, ["< 5.0", ">= 2.0.2"])
+      s.add_dependency(%q<bundler>, ["< 3.0", ">= 1.0"])
     end
   else
-    s.add_dependency(%q<public_suffix>.freeze, ["< 5.0", ">= 2.0.2"])
-    s.add_dependency(%q<bundler>.freeze, ["< 3.0", ">= 1.0"])
+    s.add_dependency(%q<public_suffix>, ["< 5.0", ">= 2.0.2"])
+    s.add_dependency(%q<bundler>, ["< 3.0", ">= 1.0"])
   end
 end


### PR DESCRIPTION
Hi there Sporkmonger,

My Pull-request deletes the `.freeze` from the gemspec file and instead adds to the top of the file the magic comment:

`# frozen_string_literal: true`

This should solve the freeze issue and makes the file a little cleaner.

I hope that helps.