### PR TITLE
fixing missing encode component documentation entry

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -421,7 +421,7 @@ module Addressable
     end
 
     class << self
-      alias_method :encode_component, :encode_component
+      alias_method :escape_component, :encode_component
     end
 
     ##


### PR DESCRIPTION
Fixing the documentation to resolve https://github.com/sporkmonger/addressable/issues/276 and add the missing docs entry for Addressable::URI.encode_component