### PR TITLE
Prefer Enumerable#flat_map over .map.flatten chain

### DIFF
--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -691,12 +691,12 @@ module Addressable
     def ordered_variable_defaults
       @ordered_variable_defaults ||= begin
         expansions, _ = parse_template_pattern(pattern)
-        expansions.map do |capture|
+        expansions.flat_map do |capture|
           _, _, varlist = *capture.match(EXPRESSION)
           varlist.split(',').map do |varspec|
             varspec[VARSPEC, 1]
           end
-        end.flatten
+        end
       end
     end
 

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -548,10 +548,10 @@ module Addressable
         leave_re = if leave_encoded.length > 0
           character_class = "#{character_class}%" unless character_class.include?('%')
 
-          "|%(?!#{leave_encoded.chars.map do |char|
+          "|%(?!#{leave_encoded.chars.flat_map do |char|
             seq = SEQUENCE_ENCODING_TABLE[char]
             [seq.upcase, seq.downcase]
-          end.flatten.join('|')})"
+          end.join('|')})"
         end
 
         character_class = /[^#{character_class}]#{leave_re}/


### PR DESCRIPTION
`#flat_map` is *generally faster* as result of not having to create an intermediate array and traverse one array lesser.

Ref: https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code