### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -31,6 +31,14 @@ namespace :gem do
     s.email = "bob@sporkmonger.com"
     s.homepage = "https://github.com/sporkmonger/addressable"
     s.license = "Apache-2.0"
+    s.metadata = {
+      "bug_tracker_uri" => "#{s.homepage}/issues",
+      "changelog_uri" => "#{s.homepage}/blob/master/CHANGELOG.md",
+      "documentation_uri" =>
+        "https://rubydoc.info/gems/#{PKG_NAME}/#{PKG_VERSION}",
+      "homepage_uri" => s.homepage,
+      "source_code_uri" => "#{s.homepage}/tree/#{PKG_NAME}-#{PKG_VERSION}"
+    }
   end
 
   Gem::PackageTask.new(GEM_SPEC) do |p|


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `homepage_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/addressable), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.