### PR TITLE
Test with truffleruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 language: ruby
 rvm:
   - jruby-9.2.9.0
-  - truffleruby
+  - truffleruby-head
   - ruby-head
   - ruby-head-clang
   - 2.0.0


### PR DESCRIPTION
Since simplecov needs a fix which is not in TruffleRuby 20.0.0,
see https://github.com/sporkmonger/addressable/pull/384

cc @dentarg 