### PR TITLE
fix: avoid some allocations of strings

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1141,7 +1141,7 @@ module Addressable
         end
       end
       # All normalized values should be UTF-8
-      unless @normalized_host.empty?
+      if @normalized_host && !@normalized_host.empty?
         @normalized_host.force_encoding(Encoding::UTF_8)
       end
       @normalized_host


### PR DESCRIPTION
Hello!
In this commit I suggest some optimizations for avoid unnecessary  strings allocations

Before (our loop of mail delivery):
```
21747764  /localgems/addressable/lib/addressable/uri.rb:557
```

After:

no any conversions from nil to empty string
