### PR TITLE
Reduce allocations in template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ matrix:
       env: IDNA_MODE=pure
       script: bundle exec rake profile:memory
       name: "Profile Memory Allocation with pure Ruby IDNA"
+    - rvm: 2.5.7
+      script: bundle exec rake profile:template_match_memory
+      name: "Profile Memory Allocation during Addressable::Template#match"
   allow_failures:
     - rvm: ruby-head
     - rvm: ruby-head-clang

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -982,6 +982,10 @@ module Addressable
     # @return [Regexp]
     #   A regular expression which may be used to parse a template pattern.
     def parse_template_pattern(pattern, processor=nil)
+      if processor.nil? && defined?(@expansions) && defined?(@template_pattern_regexp)
+        return [@expansions, @template_pattern_regexp]
+      end
+
       # Escape the pattern. The two gsubs restore the escaped curly braces
       # back to their original form. Basically, escape everything that isn't
       # within an expansion.
@@ -991,13 +995,13 @@ module Addressable
         escaped.gsub(/\\(.)/, "\\1")
       end
 
-      expansions = []
+      @expansions = []
 
       # Create a regular expression that captures the values of the
       # variables in the URI.
       regexp_string = escaped_pattern.gsub( EXPRESSION ) do |expansion|
 
-        expansions << expansion
+        @expansions << expansion
         _, operator, varlist = *expansion.match(EXPRESSION)
         leader = Regexp.escape(LEADERS.fetch(operator, ''))
         joiner = Regexp.escape(JOINERS.fetch(operator, ','))
@@ -1049,7 +1053,7 @@ module Addressable
         @template_pattern_regexp = Regexp.new(regexp_string)
       end
 
-      [expansions, @template_pattern_regexp]
+      [@expansions, @template_pattern_regexp]
     end
 
   end

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -1038,7 +1038,18 @@ module Addressable
 
       # Ensure that the regular expression matches the whole URI.
       regexp_string = "^#{regexp_string}$"
-      return expansions, Regexp.new(regexp_string)
+
+      # Cache the regexp as generating it is expensive
+      @previous_template_pattern ||= regexp_string
+      @template_pattern_regexp ||= Regexp.new(regexp_string)
+
+      # Update the cache if the regexp_string has changed
+      if regexp_string != @previous_template_pattern
+        @previous_template_pattern = regexp_string
+        @template_pattern_regexp = Regexp.new(regexp_string)
+      end
+
+      return expansions, @template_pattern_regexp
     end
 
   end

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -412,7 +412,7 @@ module Addressable
     #   match.captures
     #   #=> ["a", ["b", "c"]]
     def match(uri, processor=nil)
-      uri = Addressable::URI.parse(uri) unless uri.kind_of?(Addressable::URI)
+      uri = Addressable::URI.parse(uri) unless uri.is_a?(Addressable::URI)
       mapping = {}
 
       # First, we need to process the pattern, and extract the values.
@@ -1049,7 +1049,7 @@ module Addressable
         @template_pattern_regexp = Regexp.new(regexp_string)
       end
 
-      return expansions, @template_pattern_regexp
+      [expansions, @template_pattern_regexp]
     end
 
   end

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -412,7 +412,7 @@ module Addressable
     #   match.captures
     #   #=> ["a", ["b", "c"]]
     def match(uri, processor=nil)
-      uri = Addressable::URI.parse(uri)
+      uri = Addressable::URI.parse(uri) unless uri.kind_of?(Addressable::URI)
       mapping = {}
 
       # First, we need to process the pattern, and extract the values.

--- a/tasks/profile.rake
+++ b/tasks/profile.rake
@@ -1,6 +1,39 @@
 # frozen_string_literal: true
 
 namespace :profile do
+  desc "Profile Template memory allocations"
+  task :template_match_memory do
+    require "memory_profiler"
+    require "addressable/template"
+
+    start_at = Time.now.to_f
+    template = Addressable::Template.new("http://example.com/{?one,two,three}")
+    report = MemoryProfiler.report do
+      30_000.times do
+        template.match(
+          "http://example.com/?one=one&two=floo&three=me"
+        )
+      end
+    end
+    end_at = Time.now.to_f
+    print_options = { scale_bytes: true, normalize_paths: true }
+    puts "\n\n"
+
+    if ENV["CI"]
+      report.pretty_print(print_options)
+    else
+      t_allocated = report.scale_bytes(report.total_allocated_memsize)
+      t_retained  = report.scale_bytes(report.total_retained_memsize)
+
+      puts "Total allocated: #{t_allocated} (#{report.total_allocated} objects)"
+      puts "Total retained:  #{t_retained} (#{report.total_retained} objects)"
+      puts "Took #{end_at - start_at} seconds"
+
+      FileUtils.mkdir_p("tmp")
+      report.pretty_print(to_file: "tmp/memprof.txt", **print_options)
+    end
+  end
+
   desc "Profile memory allocations"
   task :memory do
     require "memory_profiler"


### PR DESCRIPTION
I have two commits here for speedups related to matching URIs to templates. I found these by profiling a Middleman static website build. They produce a roughly 2x increase in speed for the use case of matching 10k URIs to the same template.

The first commit avoids a duplication where #match is called with an Addressable::URI object rather than a string. 

The second commit caches the regexp produced by #parse_template_function. When match is called over and over against the same source, generating a new regexp each time is a significant part of the work done.

I did consider a wider refactor e.g. to allow to_regexp to take the optional processor as a parameter or allow the processor to be supplied via an accessor but those would require more extensive changes.

Below is a profile of a match of 10k URIs to one template. The current version (2.7.0) is on the left, this branch on the right.
![image](https://user-images.githubusercontent.com/1027215/81070943-e473d580-8edb-11ea-874e-bc0ef146e869.png)
