### PR TITLE
Surround invalid scheme with quotes to make error message more readable

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -898,7 +898,7 @@ module Addressable
         new_scheme = new_scheme.to_str
       end
       if new_scheme && new_scheme !~ /\A[a-z][a-z0-9\.\+\-]*\z/i
-        raise InvalidURIError, "Invalid scheme format: #{new_scheme}"
+        raise InvalidURIError, "Invalid scheme format: '#{new_scheme}'"
       end
       @scheme = new_scheme
       @scheme = nil if @scheme.to_s.strip.empty?

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -271,49 +271,49 @@ describe Addressable::URI, "when created from nil components" do
   it "should raise an error if the scheme is set to whitespace" do
     expect(lambda do
       @uri.scheme = "\t \n"
-    end).to raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError, /'\t \n'/)
   end
 
   it "should raise an error if the scheme is set to all digits" do
     expect(lambda do
       @uri.scheme = "123"
-    end).to raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError, /'123'/)
   end
 
   it "should raise an error if the scheme begins with a digit" do
     expect(lambda do
       @uri.scheme = "1scheme"
-    end).to raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError, /'1scheme'/)
   end
 
   it "should raise an error if the scheme begins with a plus" do
     expect(lambda do
       @uri.scheme = "+scheme"
-    end).to raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError, /'\+scheme'/)
   end
 
   it "should raise an error if the scheme begins with a dot" do
     expect(lambda do
       @uri.scheme = ".scheme"
-    end).to raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError, /'\.scheme'/)
   end
 
   it "should raise an error if the scheme begins with a dash" do
     expect(lambda do
       @uri.scheme = "-scheme"
-    end).to raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError, /'-scheme'/)
   end
 
   it "should raise an error if the scheme contains an illegal character" do
     expect(lambda do
       @uri.scheme = "scheme!"
-    end).to raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError, /'scheme!'/)
   end
 
   it "should raise an error if the scheme contains whitespace" do
     expect(lambda do
       @uri.scheme = "sch eme"
-    end).to raise_error(Addressable::URI::InvalidURIError)
+    end).to raise_error(Addressable::URI::InvalidURIError, /'sch eme'/)
   end
 
   it "should raise an error if the scheme contains a newline" do


### PR DESCRIPTION
This improves the readability of certain `Addressable::URI::InvalidURIError` messages by surrounding the offending string with single quotes to make problems like leading whitespace more visible.

Tests included.

This fixes #393.