### PR TITLE
Reduce allocations in template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ matrix:
       env: IDNA_MODE=pure
       script: bundle exec rake profile:memory
       name: "Profile Memory Allocation with pure Ruby IDNA"
+    - rvm: 2.5.7
+      script: bundle exec rake profile:template_match_memory
+      name: "Profile Memory Allocation during Addressable::Template#match"
   allow_failures:
     - rvm: ruby-head
     - rvm: ruby-head-clang

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -1038,7 +1038,18 @@ module Addressable
 
       # Ensure that the regular expression matches the whole URI.
       regexp_string = "^#{regexp_string}$"
-      return expansions, Regexp.new(regexp_string)
+
+      # Cache the regexp as generating it is expensive
+      @previous_template_pattern ||= regexp_string
+      @template_pattern_regexp ||= Regexp.new(regexp_string)
+
+      # Update the cache if the regexp_string has changed
+      if regexp_string != @previous_template_pattern
+        @previous_template_pattern = regexp_string
+        @template_pattern_regexp = Regexp.new(regexp_string)
+      end
+
+      return expansions, @template_pattern_regexp
     end
 
   end

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -974,14 +974,34 @@ module Addressable
     end
 
     ##
+    # Generates the <tt>Regexp</tt> that parses a template pattern. Memoizes the
+    # value if template processor not set (processors may not be deterministic)
+    #
+    # @param [String] pattern The URI template pattern.
+    # @param [#match] processor The template processor to use.
+    #
+    # @return [Array, Regexp]
+    #   An array of expansion variables nad a regular expression which may be
+    #   used to parse a template pattern
+    def parse_template_pattern(pattern, processor = nil)
+      if processor.nil? && pattern == @pattern
+        @cached_template_parse ||=
+          parse_new_template_pattern(pattern, processor)
+      else
+        parse_new_template_pattern(pattern, processor)
+      end
+    end
+
+    ##
     # Generates the <tt>Regexp</tt> that parses a template pattern.
     #
     # @param [String] pattern The URI template pattern.
     # @param [#match] processor The template processor to use.
     #
-    # @return [Regexp]
-    #   A regular expression which may be used to parse a template pattern.
-    def parse_template_pattern(pattern, processor=nil)
+    # @return [Array, Regexp]
+    #   An array of expansion variables nad a regular expression which may be
+    #   used to parse a template pattern
+    def parse_new_template_pattern(pattern, processor = nil)
       # Escape the pattern. The two gsubs restore the escaped curly braces
       # back to their original form. Basically, escape everything that isn't
       # within an expansion.
@@ -1038,18 +1058,7 @@ module Addressable
 
       # Ensure that the regular expression matches the whole URI.
       regexp_string = "^#{regexp_string}$"
-
-      # Cache the regexp as generating it is expensive
-      @previous_template_pattern ||= regexp_string
-      @template_pattern_regexp ||= Regexp.new(regexp_string)
-
-      # Update the cache if the regexp_string has changed
-      if regexp_string != @previous_template_pattern
-        @previous_template_pattern = regexp_string
-        @template_pattern_regexp = Regexp.new(regexp_string)
-      end
-
-      [expansions, @template_pattern_regexp]
+      return expansions, Regexp.new(regexp_string)
     end
 
   end

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -412,7 +412,7 @@ module Addressable
     #   match.captures
     #   #=> ["a", ["b", "c"]]
     def match(uri, processor=nil)
-      uri = Addressable::URI.parse(uri) unless uri.kind_of?(Addressable::URI)
+      uri = Addressable::URI.parse(uri) unless uri.is_a?(Addressable::URI)
       mapping = {}
 
       # First, we need to process the pattern, and extract the values.
@@ -1049,7 +1049,7 @@ module Addressable
         @template_pattern_regexp = Regexp.new(regexp_string)
       end
 
-      return expansions, @template_pattern_regexp
+      [expansions, @template_pattern_regexp]
     end
 
   end

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -412,7 +412,7 @@ module Addressable
     #   match.captures
     #   #=> ["a", ["b", "c"]]
     def match(uri, processor=nil)
-      uri = Addressable::URI.parse(uri)
+      uri = Addressable::URI.parse(uri) unless uri.kind_of?(Addressable::URI)
       mapping = {}
 
       # First, we need to process the pattern, and extract the values.

--- a/tasks/profile.rake
+++ b/tasks/profile.rake
@@ -1,6 +1,39 @@
 # frozen_string_literal: true
 
 namespace :profile do
+  desc "Profile Template memory allocations"
+  task :template_match_memory do
+    require "memory_profiler"
+    require "addressable/template"
+
+    start_at = Time.now.to_f
+    template = Addressable::Template.new("http://example.com/{?one,two,three}")
+    report = MemoryProfiler.report do
+      30_000.times do
+        template.match(
+          "http://example.com/?one=one&two=floo&three=me"
+        )
+      end
+    end
+    end_at = Time.now.to_f
+    print_options = { scale_bytes: true, normalize_paths: true }
+    puts "\n\n"
+
+    if ENV["CI"]
+      report.pretty_print(print_options)
+    else
+      t_allocated = report.scale_bytes(report.total_allocated_memsize)
+      t_retained  = report.scale_bytes(report.total_retained_memsize)
+
+      puts "Total allocated: #{t_allocated} (#{report.total_allocated} objects)"
+      puts "Total retained:  #{t_retained} (#{report.total_retained} objects)"
+      puts "Took #{end_at - start_at} seconds"
+
+      FileUtils.mkdir_p("tmp")
+      report.pretty_print(to_file: "tmp/memprof.txt", **print_options)
+    end
+  end
+
   desc "Profile memory allocations"
   task :memory do
     require "memory_profiler"


### PR DESCRIPTION
Starting with #389 (thanks @graemeboyd !) as the starting point and using the building blocks in #383 as @sporkmonger suggested, I went ahead and lifted up the memoization to earlier in the call stack and rebased on main. 

This had a pretty dramatic time change in the included rake task.

Before work started: 

```
Total allocated: 1.27 GB (15480016 objects)
Total retained:  320.00 B (3 objects)
Took 261.6927628517151 seconds

allocated memory by gem
-----------------------------------
   1.21 GB  addressable/lib
  54.24 MB  other

allocated memory by file
-----------------------------------
 669.06 MB  addressable/lib/addressable/uri.rb
 363.48 MB  addressable/lib/addressable/template.rb
 181.44 MB  addressable/lib/addressable/idna/pure.rb
  54.24 MB  <internal:pack>

allocated memory by location
-----------------------------------
 270.00 MB  addressable/lib/addressable/uri.rb:557
  90.63 MB  addressable/lib/addressable/uri.rb:418
  79.20 MB  addressable/lib/addressable/idna/pure.rb:181
```

After initial caching (what's in #389 ) - pretty good drop in allocations:

```
Total allocated: 1.19 GB (15390019 objects)
Total retained:  3.05 kB (6 objects)
Took 252.66562700271606 seconds

allocated memory by gem
-----------------------------------
   1.14 GB  addressable/lib
  54.24 MB  other

allocated memory by file
-----------------------------------
 669.06 MB  addressable/lib/addressable/uri.rb
 287.79 MB  addressable/lib/addressable/template.rb
 181.44 MB  addressable/lib/addressable/idna/pure.rb
  54.24 MB  <internal:pack>

allocated memory by location
-----------------------------------
 270.00 MB  addressable/lib/addressable/uri.rb:557
  90.63 MB  addressable/lib/addressable/uri.rb:418
  79.20 MB  addressable/lib/addressable/idna/pure.rb:181
  39.60 MB  addressable/lib/addressable/idna/pure.rb:180
```

Final version - a little more drop in allocation but big drop in total time:

```
Total allocated: 1.01 GB (13470083 objects)
Total retained:  3.17 kB (9 objects)
Took 178.42386198043823 seconds

allocated memory by gem
-----------------------------------
 950.83 MB  addressable/lib
  54.24 MB  other

allocated memory by file
-----------------------------------
 669.06 MB  addressable/lib/addressable/uri.rb
 181.44 MB  addressable/lib/addressable/idna/pure.rb
 100.33 MB  addressable/lib/addressable/template.rb
  54.24 MB  <internal:pack>

allocated memory by location
-----------------------------------
 270.00 MB  addressable/lib/addressable/uri.rb:557
  90.63 MB  addressable/lib/addressable/uri.rb:418
  79.20 MB  addressable/lib/addressable/idna/pure.rb:181
```
```