### PR TITLE
Memory usage and speed optimizations for `#normalize` / `.normalize_component`

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -60,7 +60,7 @@ module Addressable
       PCHAR = /[^#{CharacterClasses::PCHAR}]/
       SCHEME = /[^#{CharacterClasses::SCHEME}]/
       FRAGMENT = /[^#{CharacterClasses::FRAGMENT}]/
-      MODIFIED_QUERY = /[^a-zA-Z0-9\-\.\_\~\!\$\'\(\)\*\+\,\=\:\@\/\?%]|%(?!2B|2b)/
+      QUERY = %r{[^a-zA-Z0-9\-\.\_\~\!\$\'\(\)\*\+\,\=\:\@\/\?%]|%(?!2B|2b)}
     end
 
     SLASH = '/'
@@ -1134,7 +1134,8 @@ module Addressable
           end
           result = Addressable::URI.normalize_component(
             result,
-            NormalizeCharacterClasses::HOST)
+            NormalizeCharacterClasses::HOST
+          )
           result
         else
           EMPTY_STR.dup
@@ -1622,8 +1623,11 @@ module Addressable
         pairs.delete_if(&:empty?) if flags.include?(:compacted)
         pairs.sort! if flags.include?(:sorted)
         component = pairs.map do |pair|
-          Addressable::URI.normalize_component(pair,
-            Addressable::URI::NormalizeCharacterClasses::MODIFIED_QUERY, '+')
+          Addressable::URI.normalize_component(
+            pair,
+            Addressable::URI::NormalizeCharacterClasses::QUERY,
+            "+"
+          )
         end.join("&")
         component == "" ? nil : component
       end


### PR DESCRIPTION
Hi,

first of all thank you for maintaining this awesome library! I've been a heavy user lately and I'm glad to report I've found every feature I've wanted in this gem.

During memory profiling of my app I noticed addressable is using quite a lot of memory. In particular, `memory_profiler` gem reported this line is allocating a lot of memory:

https://github.com/sporkmonger/addressable/blob/main/lib/addressable/uri.rb#L557

This PR introduces a simple optimization to reduce `Addressable::URI#normalize` and `Addressable::URI.normalize_component` **memory usage by ~33% and increase speed by ~40%**.

Benchmarks with results are provided below. Ping me if clarifications or PR changes are needed, I'm responsive.

<hr/>

<details>
<summary>Memory profiling</summary>

Memory profiling script:

```ruby
require "memory_profiler"
require_relative "lib/addressable/uri"

MemoryProfiler.report {
  File.open("input.txt") do |file|
    10_000.times do
      string_url = file.gets(chomp: true)
      url = Addressable::URI.parse(string_url)
      url.normalize
    end
  end
}.pretty_print(
  to_file: "memory.txt",
  scale_bytes: true,
  normalize_paths: true
)
```

Input file contains 10k simple urls:

[urls.txt](https://github.com/sporkmonger/addressable/files/5749244/urls.txt)

**Results**

TL;DR before: `Total allocated: 79.39 MB`, after: `Total allocated: 54.95 MB`

[memory_before.txt](https://github.com/sporkmonger/addressable/files/5749247/memory_before.txt)

[memory_after.txt](https://github.com/sporkmonger/addressable/files/5749248/memory_after.txt)

</details>

<details>
<summary>Speed benchmarking</summary>

Benchmark script:

```ruby
require_relative "lib/addressable/uri"
require "benchmark/ips"

urls = File.readlines("urls.txt", chomp: true)
Benchmark.ips do |x|
  x.report("#normalize") do
    urls.each do |string_url|
      url = Addressable::URI.parse(string_url)
      url.normalize
    end
  end

  x.compare!
end
```

**Results**

- Before: `#normalize      1.209  (± 0.0%) i/s`
- After: `#normalize      1.676  (± 0.0%) i/s `

</details>