### PR TITLE
Only translate plus to space for http schemes

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1675,11 +1675,13 @@ module Addressable
         # so it's best to make all changes in-place.
         pair[0] = URI.unencode_component(pair[0])
         if pair[1].respond_to?(:to_str)
+          value = pair[1].to_str
           # I loathe the fact that I have to do this. Stupid HTML 4.01.
           # Treating '+' as a space was just an unbelievably bad idea.
           # There was nothing wrong with '%20'!
           # If it ain't broke, don't fix it!
-          pair[1] = URI.unencode_component(pair[1].to_str.tr("+", " "))
+          value = value.tr("+", " ") if ["http", "https", nil].include?(scheme)
+          pair[1] = URI.unencode_component(value)
         end
         if return_type == Hash
           accu[pair[0]] = pair[1]

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -4262,6 +4262,36 @@ describe Addressable::URI, "when parsed from " +
   end
 end
 
+describe Addressable::URI, "when parsed from 'https://example.com/?q=a+b'" do
+  before do
+    @uri = Addressable::URI.parse("https://example.com/?q=a+b")
+  end
+
+  it "should have query_values of {'q' => 'a b'}" do
+    expect(@uri.query_values).to eq("q" => "a b")
+  end
+end
+
+describe Addressable::URI, "when parsed from 'example.com?q=a+b'" do
+  before do
+    @uri = Addressable::URI.parse("example.com?q=a+b")
+  end
+
+  it "should have query_values of {'q' => 'a b'}" do
+    expect(@uri.query_values).to eq("q" => "a b")
+  end
+end
+
+describe Addressable::URI, "when parsed from 'mailto:?q=a+b'" do
+  before do
+    @uri = Addressable::URI.parse("mailto:?q=a+b")
+  end
+
+  it "should have query_values of {'q' => 'a+b'}" do
+    expect(@uri.query_values).to eq("q" => "a+b")
+  end
+end
+
 describe Addressable::URI, "when parsed from " +
     "'http://example.com/?q=a%2bb'" do
   before do


### PR DESCRIPTION
Prompted by a [discussion on twitter][].

Prior to this commit `Addressable::URI#query_values` replaced "+" with a space
regardless of the scheme. This makes sense for http and https, but it might not
make sense for other schemes.

For example, in the case of a mailto like
`mailto:?to=example+to@example.com&cc=example+cc@example.com`, a space
is probably not what we want, since that would not be a valid email. I
don't see explicit guidance on this in [RFC 6068][], although there
is this:

[RFC 6068]: http://www.faqs.org/rfcs/rfc6068.html

> Software creating 'mailto' URIs likewise has to be careful to encode
> any reserved characters that are used.  HTML forms are one kind of
> software that creates 'mailto' URIs.  Current implementations encode
> a space as '+', but this creates problems because such a '+' standing
> for a space cannot be distinguished from a real '+' in a 'mailto'
> URI.  When producing 'mailto' URIs, all spaces SHOULD be encoded as
> %20, and '+' characters MAY be encoded as %2B.  Please note that '+'
> characters are frequently used as part of an email address to
> indicate a subaddress, as for example in <bill+ietf@example.org>.

This commit changes the behavior of `Addressable::URI#query_values` to
only replace plus with space when the scheme is http, https or nil.

[discussion on twitter]: https://twitter.com/sporkmonger/status/1346239980717314048

cc @sporkmonger 