### PR TITLE
Hoist inline lambda to a method

### DIFF
--- a/lib/addressable/idna/pure.rb
+++ b/lib/addressable/idna/pure.rb
@@ -178,43 +178,45 @@ module Addressable
       end
 
       p = []
-      ucs4_to_utf8 = lambda do |ch|
-        if ch < 128
-          p << ch
-        elsif ch < 2048
-          p << (ch >> 6 | 192)
-          p << (ch & 63 | 128)
-        elsif ch < 0x10000
-          p << (ch >> 12 | 224)
-          p << (ch >> 6 & 63 | 128)
-          p << (ch & 63 | 128)
-        elsif ch < 0x200000
-          p << (ch >> 18 | 240)
-          p << (ch >> 12 & 63 | 128)
-          p << (ch >> 6 & 63 | 128)
-          p << (ch & 63 | 128)
-        elsif ch < 0x4000000
-          p << (ch >> 24 | 248)
-          p << (ch >> 18 & 63 | 128)
-          p << (ch >> 12 & 63 | 128)
-          p << (ch >> 6 & 63 | 128)
-          p << (ch & 63 | 128)
-        elsif ch < 0x80000000
-          p << (ch >> 30 | 252)
-          p << (ch >> 24 & 63 | 128)
-          p << (ch >> 18 & 63 | 128)
-          p << (ch >> 12 & 63 | 128)
-          p << (ch >> 6 & 63 | 128)
-          p << (ch & 63 | 128)
-        end
-      end
 
-      ucs4_to_utf8.call(ch_one)
-      ucs4_to_utf8.call(ch_two)
+      ucs4_to_utf8(ch_one, p)
+      ucs4_to_utf8(ch_two, p)
 
       return lookup_unicode_composition(p)
     end
     private_class_method :unicode_compose_pair
+
+    def self.ucs4_to_utf8(ch, buf)
+      if ch < 128
+        buf << ch
+      elsif ch < 2048
+        buf << (ch >> 6 | 192)
+        buf << (ch & 63 | 128)
+      elsif ch < 0x10000
+        buf << (ch >> 12 | 224)
+        buf << (ch >> 6 & 63 | 128)
+        buf << (ch & 63 | 128)
+      elsif ch < 0x200000
+        buf << (ch >> 18 | 240)
+        buf << (ch >> 12 & 63 | 128)
+        buf << (ch >> 6 & 63 | 128)
+        buf << (ch & 63 | 128)
+      elsif ch < 0x4000000
+        buf << (ch >> 24 | 248)
+        buf << (ch >> 18 & 63 | 128)
+        buf << (ch >> 12 & 63 | 128)
+        buf << (ch >> 6 & 63 | 128)
+        buf << (ch & 63 | 128)
+      elsif ch < 0x80000000
+        buf << (ch >> 30 | 252)
+        buf << (ch >> 24 & 63 | 128)
+        buf << (ch >> 18 & 63 | 128)
+        buf << (ch >> 12 & 63 | 128)
+        buf << (ch >> 6 & 63 | 128)
+        buf << (ch & 63 | 128)
+      end
+    end
+    private_class_method :ucs4_to_utf8
 
     def self.unicode_sort_canonical(unpacked)
       unpacked = unpacked.dup

--- a/lib/addressable/idna/pure.rb
+++ b/lib/addressable/idna/pure.rb
@@ -186,34 +186,34 @@ module Addressable
     end
     private_class_method :unicode_compose_pair
 
-    def self.ucs4_to_utf8(ch, buf)
-      if ch < 128
-        buf << ch
-      elsif ch < 2048
-        buf << (ch >> 6 | 192)
-        buf << (ch & 63 | 128)
-      elsif ch < 0x10000
-        buf << (ch >> 12 | 224)
-        buf << (ch >> 6 & 63 | 128)
-        buf << (ch & 63 | 128)
-      elsif ch < 0x200000
-        buf << (ch >> 18 | 240)
-        buf << (ch >> 12 & 63 | 128)
-        buf << (ch >> 6 & 63 | 128)
-        buf << (ch & 63 | 128)
-      elsif ch < 0x4000000
-        buf << (ch >> 24 | 248)
-        buf << (ch >> 18 & 63 | 128)
-        buf << (ch >> 12 & 63 | 128)
-        buf << (ch >> 6 & 63 | 128)
-        buf << (ch & 63 | 128)
-      elsif ch < 0x80000000
-        buf << (ch >> 30 | 252)
-        buf << (ch >> 24 & 63 | 128)
-        buf << (ch >> 18 & 63 | 128)
-        buf << (ch >> 12 & 63 | 128)
-        buf << (ch >> 6 & 63 | 128)
-        buf << (ch & 63 | 128)
+    def self.ucs4_to_utf8(char, buffer)
+      if char < 128
+        buffer << char
+      elsif char < 2048
+        buffer << (char >> 6 | 192)
+        buffer << (char & 63 | 128)
+      elsif char < 0x10000
+        buffer << (char >> 12 | 224)
+        buffer << (char >> 6 & 63 | 128)
+        buffer << (char & 63 | 128)
+      elsif char < 0x200000
+        buffer << (char >> 18 | 240)
+        buffer << (char >> 12 & 63 | 128)
+        buffer << (char >> 6 & 63 | 128)
+        buffer << (char & 63 | 128)
+      elsif char < 0x4000000
+        buffer << (char >> 24 | 248)
+        buffer << (char >> 18 & 63 | 128)
+        buffer << (char >> 12 & 63 | 128)
+        buffer << (char >> 6 & 63 | 128)
+        buffer << (char & 63 | 128)
+      elsif char < 0x80000000
+        buffer << (char >> 30 | 252)
+        buffer << (char >> 24 & 63 | 128)
+        buffer << (char >> 18 & 63 | 128)
+        buffer << (char >> 12 & 63 | 128)
+        buffer << (char >> 6 & 63 | 128)
+        buffer << (char & 63 | 128)
       end
     end
     private_class_method :ucs4_to_utf8


### PR DESCRIPTION
There's a lambda allocated inline as part of `Addressable::IDNA.unicode_compose_pair`.  This lambda is allocated, invoked twice, and discarded.

This allocation pattern is not good for performance.  Hoisting the lambda to an equivalent class method does not change behavior but yields a 47% performance improvement in `Addressable::IDNA.unicode_normalize_kc`:

    require 'benchmark/ips'
    require 'securerandom'
    require_relative 'lib/addressable'

    @strings = 100.times.map { SecureRandom.hex }

    Benchmark.ips do |x|
      x.report("after") do
        @strings.each do |string|
          Addressable::IDNA.unicode_normalize_kc(string)
        end
      end
    end

Results:

    before    194.343  (± 3.1%) i/s -    988.000  in   5.088658s
     after    285.774  (± 2.1%) i/s -      1.456k in   5.097170s

This also reduces object allocation somewhat.

`IDNA_MODE=pure bundle exec rake profile:memory` results:

Before: `Total allocated: 1.07 GB (13470014 objects)`
After: `Total allocated: 963.60 MB (12150014 objects)`