### PR TITLE
CI: Remove Ubuntu 16.04 jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,9 +99,6 @@ jobs:
         include:
           - { os: ubuntu-18.04, ruby: 2.7, gemfile: gemfiles/public_suffix_2.rb }
           - { os: ubuntu-18.04, ruby: 2.7, gemfile: gemfiles/public_suffix_3.rb }
-          # Ubuntu 16.04
-          - { os: ubuntu-16.04, ruby: 2.7 }
-          - { os: ubuntu-16.04, ruby: '3.0' }
           # Ubuntu 20.04
           - { os: ubuntu-20.04, ruby: 2.7 }
           - { os: ubuntu-20.04, ruby: '3.0' }


### PR DESCRIPTION
It is going away in the fall:

> The ubuntu-16.04 environment is deprecated and will be removed on
> September 20, 2021.

More in https://github.com/actions/virtual-environments/issues/3287