### PR TITLE
Add changelog_uri to gemspec

### DIFF
--- a/addressable.gemspec
+++ b/addressable.gemspec
@@ -20,6 +20,10 @@ Gem::Specification.new do |s|
   s.rubygems_version = "3.0.3".freeze
   s.summary = "URI Implementation".freeze
 
+  s.metadata = {
+    "changelog_uri" => "https://github.com/sporkmonger/addressable/blob/main/CHANGELOG.md"
+  }
+
   if s.respond_to? :specification_version then
     s.specification_version = 4
 


### PR DESCRIPTION
To show the link to the CHANGELOG.md on rubygems.org