### PR TITLE
CI: Use eval_gemfile from Bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gemspec(path: __FILE__ == "(eval)" ? ".." : ".")
+gemspec
 
 group :test do
   gem 'rspec', '~> 3.8'

--- a/gemfiles/public_suffix_2.rb
+++ b/gemfiles/public_suffix_2.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 # Assumes this gemfile is used from the project root
-eval File.read("Gemfile") # rubocop:disable Security/Eval
+eval_gemfile "../Gemfile"
 
 gem "public_suffix", ">= 2.0.2", "~> 2.0"

--- a/gemfiles/public_suffix_3.rb
+++ b/gemfiles/public_suffix_3.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 # Assumes this gemfile is used from the project root
-eval File.read("Gemfile") # rubocop:disable Security/Eval
+eval_gemfile "../Gemfile"
 
 gem "public_suffix", "~> 3.0"


### PR DESCRIPTION
This method isn't documented, but the RuboCop repo uses it and has been
doing so for years:

- https://github.com/rubocop/rubocop/pull/2793
- https://github.com/rubocop/rubocop/issues/3903