### PR TITLE
Use the whole string instead of a single line for template match

### DIFF
--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -1023,7 +1023,7 @@ module Addressable
       end
 
       # Ensure that the regular expression matches the whole URI.
-      regexp_string = "^#{regexp_string}$"
+      regexp_string = "\\A#{regexp_string}\\z"
       return expansions, Regexp.new(regexp_string)
     end
 

--- a/spec/addressable/template_spec.rb
+++ b/spec/addressable/template_spec.rb
@@ -78,6 +78,15 @@ describe "==" do
   end
 end
 
+describe "#to_regexp" do
+  it "does not match the first line of multiline strings" do
+    uri = "https://www.example.com/bar"
+    template = Addressable::Template.new(uri)
+    expect(template.match(uri)).not_to be_nil
+    expect(template.match("#{uri}\ngarbage")).to be_nil
+  end
+end
+
 describe "Type conversion" do
   subject {
     {


### PR DESCRIPTION
Multiline strings shouldn't pass the validation if a single line matches.