### PR TITLE
Fixed works with idn-ruby 0.1.3

### DIFF
--- a/lib/addressable/idna/native.rb
+++ b/lib/addressable/idna/native.rb
@@ -31,7 +31,8 @@ module Addressable
      end
 
     def self.unicode_normalize_kc(value)
-      IDN::Stringprep.nfkc_normalize(value.to_s)
+      str = value.to_s
+      IDN::Stringprep.nfkc_normalize(str) || str
     end
 
     def self.to_ascii(value)


### PR DESCRIPTION
(`IDN::Stringprep.nfkc_normalize(str)` returns nil for invalid UTF-8 in latest version 0.1.3).