### PR TITLE
Remove negative check for `nil`

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -126,10 +126,10 @@ module Addressable
       password = nil
       host = nil
       port = nil
-      if authority != nil
+      if authority
         # The Regexp above doesn't split apart the authority.
         userinfo = authority[/^([^\[\]]*)@/, 1]
-        if userinfo != nil
+        if userinfo
           user = userinfo.strip[/^([^:]*):?/, 1]
           password = userinfo.strip[/:(.*)$/, 1]
         end
@@ -686,7 +686,7 @@ module Addressable
         :fragment => self.unencode_component(uri_object.fragment)
       }
       components.each do |key, value|
-        if value != nil
+        if value
           begin
             components[key] =
               Addressable::IDNA.unicode_normalize_kc(value.to_str)
@@ -970,7 +970,7 @@ module Addressable
       @user = new_user ? new_user.to_str : nil
 
       # You can't have a nil user with a non-nil password
-      if password != nil
+      if password
         @user = EMPTY_STR if @user.nil?
       end
 
@@ -1031,7 +1031,7 @@ module Addressable
       # You can't have a nil user with a non-nil password
       @password ||= nil
       @user ||= nil
-      if @password != nil
+      if @password
         @user = EMPTY_STR if @user.nil?
       end
 
@@ -1242,11 +1242,11 @@ module Addressable
     def authority
       self.host && @authority ||= begin
         authority = String.new
-        if self.userinfo != nil
+        if self.userinfo
           authority << "#{self.userinfo}@"
         end
         authority << self.host
-        if self.port != nil
+        if self.port
           authority << ":#{self.port}"
         end
         authority
@@ -1261,11 +1261,11 @@ module Addressable
       return nil unless self.authority
       @normalized_authority ||= begin
         authority = String.new
-        if self.normalized_userinfo != nil
+        if self.normalized_userinfo
           authority << "#{self.normalized_userinfo}@"
         end
         authority << self.normalized_host
-        if self.normalized_port != nil
+        if self.normalized_port
           authority << ":#{self.normalized_port}"
         end
         authority
@@ -1418,7 +1418,7 @@ module Addressable
     #
     # @param [String, Integer, #to_s] new_port The new port component.
     def port=(new_port)
-      if new_port != nil && new_port.respond_to?(:to_str)
+      if new_port && new_port.respond_to?(:to_str)
         new_port = Addressable::URI.unencode_component(new_port.to_str)
       end
 
@@ -1426,9 +1426,8 @@ module Addressable
         raise InvalidURIError, "Invalid encoding in port"
       end
 
-      if new_port != nil && !(new_port.to_s =~ /^\d+$/)
-        raise InvalidURIError,
-          "Invalid port number: #{new_port.inspect}"
+      if new_port && !(new_port.to_s =~ /^\d+$/)
+        raise InvalidURIError, "Invalid port number: #{new_port.inspect}"
       end
 
       @port = new_port.to_s.to_i
@@ -1479,8 +1478,8 @@ module Addressable
     def site
       (self.scheme || self.authority) && @site ||= begin
         site_string = "".dup
-        site_string << "#{self.scheme}:" if self.scheme != nil
-        site_string << "//#{self.authority}" if self.authority != nil
+        site_string << "#{self.scheme}:" if self.scheme
+        site_string << "//#{self.authority}" if self.authority
         site_string
       end
     end
@@ -1498,10 +1497,10 @@ module Addressable
       return nil unless self.site
       @normalized_site ||= begin
         site_string = "".dup
-        if self.normalized_scheme != nil
+        if self.normalized_scheme
           site_string << "#{self.normalized_scheme}:"
         end
-        if self.normalized_authority != nil
+        if self.normalized_authority
           site_string << "//#{self.normalized_authority}"
         end
         site_string
@@ -1583,7 +1582,7 @@ module Addressable
         raise TypeError, "Can't convert #{new_path.class} into String."
       end
       @path = (new_path || EMPTY_STR).to_str
-      if !@path.empty? && @path[0..0] != SLASH && host != nil
+      if !@path.empty? && @path[0..0] != SLASH && host
         @path = "/#{@path}"
       end
 
@@ -1928,7 +1927,7 @@ module Addressable
       joined_fragment = nil
 
       # Section 5.2.2 of RFC 3986
-      if uri.scheme != nil
+      if uri.scheme
         joined_scheme = uri.scheme
         joined_user = uri.user
         joined_password = uri.password
@@ -1937,7 +1936,7 @@ module Addressable
         joined_path = URI.normalize_path(uri.path)
         joined_query = uri.query
       else
-        if uri.authority != nil
+        if uri.authority
           joined_user = uri.user
           joined_password = uri.password
           joined_host = uri.host
@@ -1947,7 +1946,7 @@ module Addressable
         else
           if uri.path == nil || uri.path.empty?
             joined_path = self.path
-            if uri.query != nil
+            if uri.query
               joined_query = uri.query
             else
               joined_query = self.query
@@ -1971,7 +1970,7 @@ module Addressable
 
               # If the base path is empty and an authority segment has been
               # defined, use a base path of SLASH
-              if base_path.empty? && self.authority != nil
+              if base_path.empty? && self.authority
                 base_path = SLASH
               end
 
@@ -2143,7 +2142,7 @@ module Addressable
         end
       end
       # Avoid network-path references.
-      if components[:host] != nil
+      if components[:host]
         components[:scheme] = normalized_self.scheme
       end
       return Addressable::URI.new(
@@ -2359,18 +2358,18 @@ module Addressable
     #
     # @return [String] The URI's <code>String</code> representation.
     def to_s
-      if self.scheme == nil && self.path != nil && !self.path.empty? &&
+      if self.scheme == nil && self.path && !self.path.empty? &&
           self.path =~ NORMPATH
         raise InvalidURIError,
           "Cannot assemble URI string with ambiguous path: '#{self.path}'"
       end
       @uri_string ||= begin
         uri_string = String.new
-        uri_string << "#{self.scheme}:" if self.scheme != nil
-        uri_string << "//#{self.authority}" if self.authority != nil
+        uri_string << "#{self.scheme}:" if self.scheme
+        uri_string << "//#{self.authority}" if self.authority
         uri_string << self.path.to_s
-        uri_string << "?#{self.query}" if self.query != nil
-        uri_string << "##{self.fragment}" if self.fragment != nil
+        uri_string << "?#{self.query}" if self.query
+        uri_string << "##{self.fragment}" if self.fragment
         uri_string.force_encoding(Encoding::UTF_8)
         uri_string
       end
@@ -2475,25 +2474,25 @@ module Addressable
     # Ensures that the URI is valid.
     def validate
       return if !!@validation_deferred
-      if self.scheme != nil && self.ip_based? &&
+      if self.scheme && self.ip_based? &&
           (self.host == nil || self.host.empty?) &&
           (self.path == nil || self.path.empty?)
         raise InvalidURIError,
           "Absolute URI missing hierarchical segment: '#{self.to_s}'"
       end
       if self.host == nil
-        if self.port != nil ||
-            self.user != nil ||
-            self.password != nil
+        if self.port ||
+            self.user ||
+            self.password
           raise InvalidURIError, "Hostname not supplied: '#{self.to_s}'"
         end
       end
-      if self.path != nil && !self.path.empty? && self.path[0..0] != SLASH &&
-          self.authority != nil
+      if self.path && !self.path.empty? && self.path[0..0] != SLASH &&
+          self.authority
         raise InvalidURIError,
           "Cannot have a relative path with an authority set: '#{self.to_s}'"
       end
-      if self.path != nil && !self.path.empty? &&
+      if self.path && !self.path.empty? &&
           self.path[0..1] == SLASH + SLASH && self.authority == nil
         raise InvalidURIError,
           "Cannot have a path with two leading slashes " +
@@ -2502,7 +2501,7 @@ module Addressable
       unreserved = CharacterClasses::UNRESERVED
       sub_delims = CharacterClasses::SUB_DELIMS
       if !self.host.nil? && (self.host =~ /[<>{}\/\\\?\#\@"[[:space:]]]/ ||
-          (self.host[/^\[(.*)\]$/, 1] != nil && self.host[/^\[(.*)\]$/, 1] !~
+          (self.host[/^\[(.*)\]$/, 1] && self.host[/^\[(.*)\]$/, 1] !~
           Regexp.new("^[#{unreserved}#{sub_delims}:]*$")))
         raise InvalidURIError, "Invalid character in host: '#{self.host.to_s}'"
       end


### PR DESCRIPTION
Technically, if an object is not `nil`, it is either a Boolean `false` or a *truthy*.

I'm making *an assumption* here that `false` can be ignored because this check is used against values set by `:parse` method.
Therefore, the test for `!= nil` is redundant.
