### PR TITLE
Explicitly freeze concatenated-`String` constants to unbreak on non-main `Ractor`s.

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -38,20 +38,26 @@ module Addressable
     ##
     # Container for the character classes specified in
     # <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a>.
+    #
+    # Note: Concatenated and interpolated `String`s are not affected by the
+    #       `frozen_string_literal` directive and must be frozen explicitly.
+    #
+    #       Interpolated `String`s *were* frozen this way before Ruby 3.0:
+    #       https://bugs.ruby-lang.org/issues/17104
     module CharacterClasses
       ALPHA = "a-zA-Z"
       DIGIT = "0-9"
       GEN_DELIMS = "\\:\\/\\?\\#\\[\\]\\@"
       SUB_DELIMS = "\\!\\$\\&\\'\\(\\)\\*\\+\\,\\;\\="
-      RESERVED = GEN_DELIMS + SUB_DELIMS
-      UNRESERVED = ALPHA + DIGIT + "\\-\\.\\_\\~"
-      PCHAR = UNRESERVED + SUB_DELIMS + "\\:\\@"
-      SCHEME = ALPHA + DIGIT + "\\-\\+\\."
-      HOST = UNRESERVED + SUB_DELIMS + "\\[\\:\\]"
-      AUTHORITY = PCHAR + "\\[\\:\\]"
-      PATH = PCHAR + "\\/"
-      QUERY = PCHAR + "\\/\\?"
-      FRAGMENT = PCHAR + "\\/\\?"
+      RESERVED = (GEN_DELIMS + SUB_DELIMS).freeze
+      UNRESERVED = (ALPHA + DIGIT + "\\-\\.\\_\\~").freeze
+      PCHAR = (UNRESERVED + SUB_DELIMS + "\\:\\@").freeze
+      SCHEME = (ALPHA + DIGIT + "\\-\\+\\.").freeze
+      HOST = (UNRESERVED + SUB_DELIMS + "\\[\\:\\]").freeze
+      AUTHORITY = (PCHAR + "\\[\\:\\]").freeze
+      PATH = (PCHAR + "\\/").freeze
+      QUERY = (PCHAR + "\\/\\?").freeze
+      FRAGMENT = (PCHAR + "\\/\\?").freeze
     end
 
     module NormalizeCharacterClasses

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -6663,3 +6663,13 @@ describe Addressable::URI, "when initializing a subclass of Addressable::URI" do
     expect(@uri.class).to eq(@uri.join('path').class)
   end
 end
+
+describe Addressable::URI, "when initialized in a non-main `Ractor`" do
+  it "should have the same value as if used in the main `Ractor`" do
+    pending("Ruby 3.0+ for `Ractor` support") unless defined?(Ractor)
+    main = Addressable::URI.parse("http://example.com")
+    expect(
+      Ractor.new { Addressable::URI.parse("http://example.com") }.take
+    ).to eq(main)
+  end
+end


### PR DESCRIPTION
When building `String`s with the `String#concat` / `String#+` methods, the receiver and argument `String`s are literals, but the resulting value is not, so they are left unfrozen when we rely only on the `frozen_string_literal` directive.

Switch to the [`%q` non-interpolable `String` literal syntax](https://docs.ruby-lang.org/en/master/doc/syntax/literals_rdoc.html#label-25q-3A+Non-Interpolable+String+Literals) for these because it feels less gross to me than e.g. `HOST = (UNRESERVED + SUB_DELIMS + "\\[\\:\\]").freeze`. This syntax [was present in Ruby 2.0](https://docs.ruby-lang.org/en/2.0.0/syntax/literals_rdoc.html#label-Percent+Strings), which is Addressable's minimum requirement :)

## Before
Concatenated `String`s are not frozen when the `frozen_string_literal: true` directive is used.

```
[okeeblow@emi#CHECKING YOU OUT] ruby2.7 -r 'addressable' -e 'Addressable::URI::CharacterClasses::constants::each { p "#{_1} frozen? #{Addressable::URI::CharacterClasses::const_get(_1).frozen?}" }'
"ALPHA frozen? true"
"DIGIT frozen? true"
"GEN_DELIMS frozen? true"
"SUB_DELIMS frozen? true"
"RESERVED frozen? false"
"UNRESERVED frozen? false"
"PCHAR frozen? false"
"SCHEME frozen? false"
"HOST frozen? false"
"AUTHORITY frozen? false"
"PATH frozen? false"
"QUERY frozen? false"
"FRAGMENT frozen? false"
```

…and we encounter a `Ractor::IsolationError` when trying to use `Addressable::URI::parse` in a non-main `Ractor`:

```
[okeeblow@emi#CHECKING YOU OUT] ruby -v
ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [x86_64-linux]

[okeeblow@emi#CHECKING YOU OUT] ruby -r 'addressable' -e 'Addressable::URI::CharacterClasses::constants::each { value = Addressable::URI::CharacterClasses::const_get(_1); p "#{_1} frozen? #{_1.frozen?}; shareable? #{Ractor::shareable?(value)}"}'
"ALPHA frozen? true; shareable? true"
"DIGIT frozen? true; shareable? true"
"GEN_DELIMS frozen? true; shareable? true"
"SUB_DELIMS frozen? true; shareable? true"
"RESERVED frozen? true; shareable? false"
"UNRESERVED frozen? true; shareable? false"
"PCHAR frozen? true; shareable? false"
"SCHEME frozen? true; shareable? false"
"HOST frozen? true; shareable? false"
"AUTHORITY frozen? true; shareable? false"
"PATH frozen? true; shareable? false"
"QUERY frozen? true; shareable? false"
"FRAGMENT frozen? true; shareable? false"
```

```
irb(main):070:0> Ractor::new { Addressable::URI::parse('https://cooltrainer.org') }
#<Thread:0x00007f1e35a2e0e0 run> terminated with exception (report_on_exception is true):
/home/okeeblow/.gems/gems/addressable-2.8.0/lib/addressable/uri.rb:2497:in `validate': can not access non-shareable objects in constant Addressable::URI::CharacterClasses::UNRESERVED by non-main Ractor. (Ractor::IsolationError)                                               
        from /home/okeeblow/.gems/gems/addressable-2.8.0/lib/addressable/uri.rb:2421:in `defer_validation'
        from /home/okeeblow/.gems/gems/addressable-2.8.0/lib/addressable/uri.rb:840:in `initialize'
        from /home/okeeblow/.gems/gems/addressable-2.8.0/lib/addressable/uri.rb:147:in `new'
        from /home/okeeblow/.gems/gems/addressable-2.8.0/lib/addressable/uri.rb:147:in `parse'
        from (irb):70:in `block in <top (required)>'
=> #<Ractor:#11 (irb):70 terminated>
```

## After
`String`s are frozen, and Addressable can be used in a non-main `Ractor`:

```
[okeeblow@emi#CHECKING YOU OUT] ruby -v
ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [x86_64-linux]

[okeeblow@emi#CHECKING YOU OUT] bundle exec ruby -r 'addressable' -e 'Addressable::URI::CharacterClasses::constants::each { value = Addressable::URI::CharacterClasses::const_get(_1); p "#{_1} frozen? #{_1.frozen?}; shareable? #{Ractor::shareable?(value)}"}'
"ALPHA frozen? true; shareable? true"
"DIGIT frozen? true; shareable? true"
"GEN_DELIMS frozen? true; shareable? true"
"SUB_DELIMS frozen? true; shareable? true"
"RESERVED frozen? true; shareable? false"
"UNRESERVED frozen? true; shareable? false"
"PCHAR frozen? true; shareable? false"
"SCHEME frozen? true; shareable? false"
"HOST frozen? true; shareable? false"
"AUTHORITY frozen? true; shareable? false"
"PATH frozen? true; shareable? false"
"QUERY frozen? true; shareable? false"
"FRAGMENT frozen? true; shareable? false"
```

Even though `Ractor::shareable?` still returns `false` here, the [Ractor "shareable objects" docs](https://docs.ruby-lang.org/en/master/doc/ractor_md.html#label-Shareable+objects) say frozen `String` objects are shareable. We could additionally call `Ractor::make_shareable`, but there seems to be no reason to since it does work:

```
[okeeblow@emi#CHECKING YOU OUT] ./bin/repl
irb(main):001:0> Ractor::new { Addressable::URI::parse('https://cooltrainer.org') }.take
=> #<Addressable::URI:0x1ae0 URI:https://cooltrainer.org>
```
