### PR TITLE
CI: Add Ruby 3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,7 @@ jobs:
           - 2.7
           # quotes because of YAML gotcha: https://github.com/actions/runner/issues/849
           - '3.0'
+          - 3.1
           - head
           - jruby-9.1
           - jruby-9.2
@@ -103,6 +104,7 @@ jobs:
           # Ubuntu 20.04
           - { os: ubuntu-20.04, ruby: 2.7 }
           - { os: ubuntu-20.04, ruby: '3.0' }
+          - { os: ubuntu-20.04, ruby: 3.1 }
           # macOS
           - { os: macos-10.15,  ruby: 2.7 }
           - { os: macos-10.15,  ruby: '3.0' }
@@ -110,11 +112,13 @@ jobs:
           - { os: macos-10.15,  ruby: truffleruby-21.1 }
           - { os: macos-11,     ruby: 2.7 }
           - { os: macos-11,     ruby: '3.0' }
+          - { os: macos-11,     ruby: 3.1 }
           - { os: macos-11,     ruby: jruby }
           - { os: macos-11,     ruby: truffleruby-21.1 }
           # Windows
           - { os: windows-2019, ruby: 2.7 }
           - { os: windows-2019, ruby: '3.0' }
+          - { os: windows-2019, ruby: 3.1 }
           - { os: windows-2019, ruby: jruby-9.1 }
           - { os: windows-2019, ruby: jruby-9.2 }
           # allowed to fail


### PR DESCRIPTION
Intentionally left out Ruby 3.1 for `macos-10.15` to keep number of macOS jobs down as they are a bit slow.