### PR TITLE
CI: Use TruffleRuby 21.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,8 +92,7 @@ jobs:
           - jruby-9.2
           - jruby-9.3
           - jruby-head
-          # truffleruby-21.2 fails due to https://github.com/oracle/truffleruby/issues/2408
-          - truffleruby-21.1
+          - truffleruby-21.3
           - truffleruby-head
         os:
           - ubuntu-18.04
@@ -110,12 +109,12 @@ jobs:
           - { os: macos-10.15,  ruby: 2.7 }
           - { os: macos-10.15,  ruby: '3.0' }
           - { os: macos-10.15,  ruby: jruby }
-          - { os: macos-10.15,  ruby: truffleruby-21.1 }
+          - { os: macos-10.15,  ruby: truffleruby-21.3 }
           - { os: macos-11,     ruby: 2.7 }
           - { os: macos-11,     ruby: '3.0' }
           - { os: macos-11,     ruby: 3.1 }
           - { os: macos-11,     ruby: jruby }
-          - { os: macos-11,     ruby: truffleruby-21.1 }
+          - { os: macos-11,     ruby: truffleruby-21.3 }
           # Windows
           - { os: windows-2019, ruby: 2.7 }
           - { os: windows-2019, ruby: '3.0' }


### PR DESCRIPTION
https://github.com/oracle/truffleruby/issues/2408 was addressed in TruffleRuby 21.3.