### PR TITLE
CI: Add one Windows 2022 job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,7 @@ jobs:
           - { os: windows-2019, ruby: 2.7 }
           - { os: windows-2019, ruby: '3.0' }
           - { os: windows-2019, ruby: 3.1 }
+          - { os: windows-2022, ruby: 3.1 }
           - { os: windows-2019, ruby: jruby-9.1 }
           - { os: windows-2019, ruby: jruby-9.2 }
           - { os: windows-2019, ruby: jruby-9.3 }


### PR DESCRIPTION
https://github.blog/changelog/2021-08-23-github-actions-windows-server-2022-with-visual-studio-2022-is-now-available-on-github-hosted-runners-public-beta/