### PR TITLE
fix `invalid byte sequence in UTF-8` exception when unencoding URLs containing non UTF-8 characters

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -468,19 +468,13 @@ module Addressable
           "Expected Class (String or Addressable::URI), " +
           "got #{return_type.inspect}"
       end
-      uri = uri.dup
-      # Seriously, only use UTF-8. I'm really not kidding!
-      uri.force_encoding("utf-8")
 
-      unless leave_encoded.empty?
-        leave_encoded = leave_encoded.dup.force_encoding("utf-8")
-      end
-
-      result = uri.gsub(/%[0-9a-f]{2}/iu) do |sequence|
+      result = uri.gsub(/%[0-9a-f]{2}/i) do |sequence|
         c = sequence[1..3].to_i(16).chr
-        c.force_encoding("utf-8")
+        c.force_encoding(sequence.encoding)
         leave_encoded.include?(c) ? sequence : c
       end
+
       result.force_encoding("utf-8")
       if return_type == String
         return result

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -5992,6 +5992,11 @@ describe Addressable::URI, "when unencoding a multibyte string" do
     expect(Addressable::URI.unencode_component("ski=%BA%DAɫ")).to eq("ski=\xBA\xDAɫ")
   end
 
+  it "should not fail with UTF-8 incompatible string" do
+    url = "/M%E9/\xE9?p=\xFC".b
+    expect(Addressable::URI.unencode_component(url)).to eq("/M\xE9/\xE9?p=\xFC")
+  end
+
   it "should result in correct percent encoded sequence as a URI" do
     expect(Addressable::URI.unencode(
       "/path?g%C3%BCnther", ::Addressable::URI


### PR DESCRIPTION
Hi :wave: 

First of all I've been using `addressable` for some time in [my product](https://updown.io) to deal with complex URL transformations and it's been super helpfull. Thanks :bow: 

Recently I started getting one `invalid byte sequence in UTF-8` exception in `gsub` when parsing and normalizing some weird URL containing non UTF-8 compatible characters (ISO-8859-1). So I looked at the code and found that it is supposed to change the encoding back to ASCII-8BIT during this phase to avoid any encoding issue (good idea):
https://github.com/sporkmonger/addressable/blob/addressable-2.8.0/lib/addressable/uri.rb#L576-L580

BUT a couple lines later in the `unencode` method it actually forces back to UTF-8 right BEFORE the gsub:
https://github.com/sporkmonger/addressable/blob/addressable-2.8.0/lib/addressable/uri.rb#L472-L480

(this is comming from this change: https://github.com/sporkmonger/addressable/commit/e4f2bd64592d59a72c190daa4eae98faa157c3c6 following this issue: https://github.com/sporkmonger/addressable/issues/154)

So this change back to UTF-8 before the gsub is breaking again this workflow, the spec I added in this PR gives this failure using the original code:
```
Failures:

  1) Addressable::URI when unencoding a multibyte string should not fail with UTF-8 incompatible string (ISO-8859-1 encoding in this example)
     Failure/Error:
       result = uri.gsub(/%[0-9a-f]{2}/iu) do |sequence|
         c = sequence[1..3].to_i(16).chr
         c.force_encoding("utf-8")
         leave_encoded.include?(c) ? sequence : c
       end
     
     ArgumentError:
       invalid byte sequence in UTF-8
     # ./lib/addressable/uri.rb:480:in `gsub'
     # ./lib/addressable/uri.rb:480:in `unencode'
     # ./spec/addressable/uri_spec.rb:5997:in `block (2 levels) in <top (required)>'
```

My fix simply removes some of the `force_encoding` and changes slightly the one inside the gsub (to avoid breaking the other issue fixed before). The test suite passes entirely and I have also checked this version on the 150k+ URLs present in my product (parse + normalize) without any error. I am already using this version in production for about a week.

Let me know if you have any doubt or questions.

Suggested line for the changelog:
```
- fixes "invalid byte sequence in UTF-8" exception when unencoding URLs containing non UTF-8 characters
```