### PR TITLE
Loosen public suffix restriction to allow version 5.0

### DIFF
--- a/addressable.gemspec
+++ b/addressable.gemspec
@@ -24,14 +24,14 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<public_suffix>.freeze, [">= 2.0.2", "< 5.0"])
+      s.add_runtime_dependency(%q<public_suffix>.freeze, [">= 2.0.2", "< 6.0"])
       s.add_development_dependency(%q<bundler>.freeze, [">= 1.0", "< 3.0"])
     else
-      s.add_dependency(%q<public_suffix>.freeze, [">= 2.0.2", "< 5.0"])
+      s.add_dependency(%q<public_suffix>.freeze, [">= 2.0.2", "< 6.0"])
       s.add_dependency(%q<bundler>.freeze, [">= 1.0", "< 3.0"])
     end
   else
-    s.add_dependency(%q<public_suffix>.freeze, [">= 2.0.2", "< 5.0"])
+    s.add_dependency(%q<public_suffix>.freeze, [">= 2.0.2", "< 6.0"])
     s.add_dependency(%q<bundler>.freeze, [">= 1.0", "< 3.0"])
   end
 end


### PR DESCRIPTION
public_suffix 5.0 was just released.  It includes updated definitions, and is restricted to Ruby 2.6+.

Loosening this gemspec restriction allows addressable to use the latest version of public_suffix when loaded with a supported Ruby (2.6+).