### PR TITLE
Avoid installing `idn-ruby` if `IDNA_MODE=pure`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,4 +25,6 @@ group :test, :development do
   gem "rake", ">= 12.3.3"
 end
 
-gem "idn-ruby", platform: :mri
+unless ENV["IDNA_MODE"] == "pure"
+  gem "idn-ruby", platform: :mri
+end


### PR DESCRIPTION
Makes it easier to do a quick test in Docker like this

    $ docker run --rm -it -v $(pwd):/app -w /app ruby:3.1 bash
    root@caa1b64ea763:/app# BUNDLE_WITHOUT=development:coverage IDNA_MODE=pure bundle
    ...