### PR TITLE
Set required Ruby version to >= 2.2 in gemspec

### DIFF
--- a/addressable.gemspec
+++ b/addressable.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/sporkmonger/addressable".freeze
   s.licenses = ["Apache-2.0".freeze]
   s.rdoc_options = ["--main".freeze, "README.md".freeze]
-  s.required_ruby_version = Gem::Requirement.new(">= 2.0".freeze)
+  s.required_ruby_version = Gem::Requirement.new(">= 2.2".freeze)
   s.rubygems_version = "3.0.3".freeze
   s.summary = "URI Implementation".freeze
 


### PR DESCRIPTION
Addressable 2.8.0 (892861d (part of #416)) dropped support for Ruby 2.0, 2.1.