### PR TITLE
Set required Ruby to >= 2.2 in gemspec task

### DIFF
--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -19,7 +19,7 @@ namespace :gem do
       exit(1)
     end
 
-    s.required_ruby_version = ">= 2.0"
+    s.required_ruby_version = ">= 2.2"
 
     s.add_runtime_dependency "public_suffix", ">= 2.0.2", "< 5.0"
     s.add_development_dependency "bundler", ">= 1.0", "< 3.0"


### PR DESCRIPTION
Addressable 2.8.0 (892861d (part of #416)) dropped support for Ruby 2.0, 2.1.

Follow-up to #463