### PR TITLE
Magic encoding comment on the first line

### DIFF
--- a/lib/addressable/idna.rb
+++ b/lib/addressable/idna.rb
@@ -1,6 +1,6 @@
+# encoding: UTF-8
 # frozen_string_literal: true
 
-# encoding:utf-8
 #--
 # Copyright (C) Bob Aman
 #

--- a/lib/addressable/idna/native.rb
+++ b/lib/addressable/idna/native.rb
@@ -1,6 +1,6 @@
+# encoding: UTF-8
 # frozen_string_literal: true
 
-# encoding:utf-8
 #--
 # Copyright (C) Bob Aman
 #

--- a/lib/addressable/idna/pure.rb
+++ b/lib/addressable/idna/pure.rb
@@ -1,6 +1,6 @@
+# encoding: UTF-8
 # frozen_string_literal: true
 
-# encoding:utf-8
 #--
 # Copyright (C) Bob Aman
 #

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -1,6 +1,6 @@
+# encoding: UTF-8
 # frozen_string_literal: true
 
-# encoding:utf-8
 #--
 # Copyright (C) Bob Aman
 #

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1,6 +1,6 @@
+# encoding: UTF-8
 # frozen_string_literal: true
 
-# encoding:utf-8
 #--
 # Copyright (C) Bob Aman
 #

--- a/lib/addressable/version.rb
+++ b/lib/addressable/version.rb
@@ -1,6 +1,6 @@
+# encoding: UTF-8
 # frozen_string_literal: true
 
-# encoding:utf-8
 #--
 # Copyright (C) Bob Aman
 #

--- a/spec/addressable/idna_spec.rb
+++ b/spec/addressable/idna_spec.rb
@@ -1,6 +1,6 @@
+# encoding: UTF-8
 # frozen_string_literal: true
 
-# coding: utf-8
 # Copyright (C) Bob Aman
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/addressable/net_http_compat_spec.rb
+++ b/spec/addressable/net_http_compat_spec.rb
@@ -1,6 +1,6 @@
+# encoding: UTF-8
 # frozen_string_literal: true
 
-# coding: utf-8
 # Copyright (C) Bob Aman
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/addressable/security_spec.rb
+++ b/spec/addressable/security_spec.rb
@@ -1,6 +1,6 @@
+# encoding: UTF-8
 # frozen_string_literal: true
 
-# coding: utf-8
 # Copyright (C) Bob Aman
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/addressable/template_spec.rb
+++ b/spec/addressable/template_spec.rb
@@ -1,6 +1,6 @@
+# encoding: UTF-8
 # frozen_string_literal: true
 
-# coding: utf-8
 # Copyright (C) Bob Aman
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -1,6 +1,6 @@
+# encoding: UTF-8
 # frozen_string_literal: true
 
-# coding: utf-8
 # Copyright (C) Bob Aman
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
...so it works. #309 got this wrong.

See https://ruby-doc.org/core-3.0.0/Encoding.html#class-Encoding-label-Script+encoding

Close #423