### PR TITLE
Remove all magic comments about encoding

### DIFF
--- a/lib/addressable/idna.rb
+++ b/lib/addressable/idna.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# encoding:utf-8
 #--
 # Copyright (C) Bob Aman
 #

--- a/lib/addressable/idna/native.rb
+++ b/lib/addressable/idna/native.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# encoding:utf-8
 #--
 # Copyright (C) Bob Aman
 #

--- a/lib/addressable/idna/pure.rb
+++ b/lib/addressable/idna/pure.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# encoding:utf-8
 #--
 # Copyright (C) Bob Aman
 #

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# encoding:utf-8
 #--
 # Copyright (C) Bob Aman
 #

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# encoding:utf-8
 #--
 # Copyright (C) Bob Aman
 #

--- a/lib/addressable/version.rb
+++ b/lib/addressable/version.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# encoding:utf-8
 #--
 # Copyright (C) Bob Aman
 #

--- a/spec/addressable/idna_spec.rb
+++ b/spec/addressable/idna_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# coding: utf-8
 # Copyright (C) Bob Aman
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/addressable/net_http_compat_spec.rb
+++ b/spec/addressable/net_http_compat_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# coding: utf-8
 # Copyright (C) Bob Aman
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/addressable/security_spec.rb
+++ b/spec/addressable/security_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# coding: utf-8
 # Copyright (C) Bob Aman
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/addressable/template_spec.rb
+++ b/spec/addressable/template_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# coding: utf-8
 # Copyright (C) Bob Aman
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# coding: utf-8
 # Copyright (C) Bob Aman
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
They only work when they are on the first line as pointed out by https://github.com/sporkmonger/addressable/issues/423
(#309 broke that when adding the frozen_string_literal pragma)

UTF-8 is the default (as pointed out by our bot in #467), so remove them.

https://ruby-doc.org/core-3.0.0/Encoding.html#class-Encoding-label-Script+encoding says

> The default script encoding is Encoding::UTF_8 after v2.0

and we are not supporting Ruby <2, so we should be good

Close #423
Close https://github.com/sporkmonger/addressable/pull/467