### PR TITLE
CI: remove Ubuntu 18.04 job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,6 @@ jobs:
           - { os: ubuntu-20.04, ruby: 2.7, gemfile: gemfiles/public_suffix_3.rb }
           - { os: ubuntu-20.04, ruby: 2.7, gemfile: gemfiles/public_suffix_4.rb }
           # Ubuntu
-          - { os: ubuntu-18.04, ruby: 2.7 }
           - { os: ubuntu-22.04, ruby: 3.1 }
           # macOS
           - { os: macos-11,     ruby: 3.1 }


### PR DESCRIPTION
GitHub Actions will remove the Ubuntu 18.04 image in December and have brownouts before that: https://github.com/actions/runner-images/issues/6002