### PR TITLE
Ensure reset of deferred validation

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -2408,7 +2408,8 @@ module Addressable
       yield
       @validation_deferred = false
       validate
-      return nil
+    ensure
+      @validation_deferred = false
     end
 
   protected

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -6755,7 +6755,7 @@ describe Addressable::URI, "when deferring validation" do
     end
   end
 
-  it "always resets deferal afterward" do
+  it "always resets deferral afterward" do
     expect { uri.defer_validation { raise "boom" } }.to raise_error("boom")
     expect(deferred).to be false
   end

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -6743,3 +6743,25 @@ describe Addressable::URI, "when initialized in a non-main `Ractor`" do
     ).to eq(main)
   end
 end
+
+describe Addressable::URI, "when deferring validation" do
+  subject(:deferred) { uri.instance_variable_get(:@validation_deferred) }
+
+  let(:uri) { Addressable::URI.parse("http://example.com") }
+
+  it "defers validation within the block" do
+    uri.defer_validation do
+      expect(deferred).to be true
+    end
+  end
+
+  it "always resets deferal afterward" do
+    expect { uri.defer_validation { raise "boom" } }.to raise_error("boom")
+    expect(deferred).to be false
+  end
+
+  it "returns nil" do
+    res = uri.defer_validation {}
+    expect(res).to be nil
+  end
+end


### PR DESCRIPTION
I was digging through this code and noticed a few things that could be tightened up (it's generally an awesome library though, so thanks!).  Forgive me if this is unwelcomed feedback.

There is an edge case where the block in defer_validation could raises an exception and validation_deferred isn't reset properly.  Perhaps contrived, but I thought it worth addressing.  The rest are more cosmetic suggestions to make this code simpler / more Rubyish