### PR TITLE
Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,7 @@ jobs:
           # quotes because of YAML gotcha: https://github.com/actions/runner/issues/849
           - '3.0'
           - 3.1
+          - 3.2
           - head
           - jruby-9.1
           - jruby-9.2


### PR DESCRIPTION
Aside from a truffleruby job failure, this runs green on my fork.