### PR TITLE
Add JRuby 9.4, TruffleRuby 22.2, 22.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,8 +91,10 @@ jobs:
           - jruby-9.1
           - jruby-9.2
           - jruby-9.3
-          - truffleruby-21.3
+          - jruby-9.4
           - truffleruby-22.1
+          - truffleruby-22.2
+          - truffleruby-22.3
         os:
           - ubuntu-20.04
         gemfile:
@@ -113,6 +115,8 @@ jobs:
           # allowed to fail
           - { os: ubuntu-20.04, ruby: jruby-head, gemfile: Gemfile, allow-failure: true }
           - { os: ubuntu-20.04, ruby: truffleruby-head, gemfile: Gemfile, allow-failure: true }
+          # because of https://github.com/ruby/setup-ruby/issues/433
+          - { os: ubuntu-20.04, ruby: truffleruby-21.3, gemfile: Gemfile, allow-failure: true }
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
       BUNDLE_WITHOUT: development:coverage


### PR DESCRIPTION
Allow TruffleRuby 21.3 to fail for now (can't use latest Bundler release).