### PR TITLE
CI: remove truffleruby-21.3 from matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,8 +116,6 @@ jobs:
           # allowed to fail
           - { os: ubuntu-20.04, ruby: jruby-head, gemfile: Gemfile, allow-failure: true }
           - { os: ubuntu-20.04, ruby: truffleruby-head, gemfile: Gemfile, allow-failure: true }
-          # because of https://github.com/ruby/setup-ruby/issues/433
-          - { os: ubuntu-20.04, ruby: truffleruby-21.3, gemfile: Gemfile, allow-failure: true }
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
       BUNDLE_WITHOUT: development:coverage


### PR DESCRIPTION
It is not a supported release anymore, and it does not work with latest bundler (2.4): https://github.com/ruby/setup-ruby/issues/433#issuecomment-1367991816

Close #489