### PR TITLE
Use ruby unicode normalize to avoid libidn C problems and heavy legacy ruby code

### DIFF
--- a/benchmark/unicode_normalize.rb
+++ b/benchmark/unicode_normalize.rb
@@ -1,0 +1,34 @@
+# /usr/bin/env ruby
+# frozen_string_literal: true.
+
+require "benchmark"
+require "addressable/idna/pure.rb"
+require "idn"
+
+value = "ﬁﾯリ宠퐱卄.com"
+expected = "fiᆵリ宠퐱卄.com"
+N = 100_000
+
+fail "ruby does not match" unless expected == value.unicode_normalize(:nfkc)
+fail "libidn does not match" unless expected == IDN::Stringprep.nfkc_normalize(value)
+fail "addressable does not match" unless expected == Addressable::IDNA.unicode_normalize_kc(value)
+
+Benchmark.bmbm do |x|
+  x.report("pure") { N.times { Addressable::IDNA.unicode_normalize_kc(value) } }
+  x.report("libidn") { N.times { IDN::Stringprep.nfkc_normalize(value) } }
+  x.report("ruby") { N.times { value.unicode_normalize(:nfkc) } }
+end
+
+# February 14th 2023, before replacing the legacy pure normalize code:
+
+# > ruby benchmark/unicode_normalize.rb
+# Rehearsal ------------------------------------------
+# pure     1.335230   0.000315   1.335545 (  1.335657)
+# libidn   0.058568   0.000000   0.058568 (  0.058570)
+# ruby     0.326008   0.000014   0.326022 (  0.326026)
+# --------------------------------- total: 1.720135sec
+
+#              user     system      total        real
+# pure     1.325948   0.000000   1.325948 (  1.326054)
+# libidn   0.058067   0.000000   0.058067 (  0.058069)
+# ruby     0.325062   0.000000   0.325062 (  0.325115)

--- a/lib/addressable/idna/native.rb
+++ b/lib/addressable/idna/native.rb
@@ -29,10 +29,6 @@ module Addressable
        IDN::Punycode.decode(value.to_s)
      end
 
-    def self.unicode_normalize_kc(value)
-      IDN::Stringprep.nfkc_normalize(value.to_s)
-    end
-
     def self.to_ascii(value)
       value.to_s.split('.', -1).map do |segment|
         if segment.size > 0 && segment.size < 64

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -892,7 +892,7 @@ module Addressable
     # operator.
     #
     # @param [Hash, Array, String] value
-    #   Normalizes keys and values with IDNA#unicode_normalize_kc
+    #   Normalizes unicode keys and values with String#unicode_normalize (NFC)
     #
     # @return [Hash, Array, String] The normalized values
     def normalize_value(value)
@@ -902,15 +902,17 @@ module Addressable
 
       # Handle unicode normalization
       if value.kind_of?(Array)
-        value.map! { |val| Addressable::IDNA.unicode_normalize_kc(val) }
+        value.map! { |val| normalize_value(val) }
       elsif value.kind_of?(Hash)
         value = value.inject({}) { |acc, (k, v)|
-          acc[Addressable::IDNA.unicode_normalize_kc(k)] =
-            Addressable::IDNA.unicode_normalize_kc(v)
+          acc[normalize_value(k)] = normalize_value(v)
           acc
         }
       else
-        value = Addressable::IDNA.unicode_normalize_kc(value)
+        if value.encoding != Encoding::UTF_8
+          value = value.dup.force_encoding(Encoding::UTF_8)
+        end
+        value = value.unicode_normalize(:nfc)
       end
       value
     end

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -53,7 +53,7 @@ module Addressable
       PCHAR = (UNRESERVED + SUB_DELIMS + "\\:\\@").freeze
       SCHEME = (ALPHA + DIGIT + "\\-\\+\\.").freeze
       HOST = (UNRESERVED + SUB_DELIMS + "\\[\\:\\]").freeze
-      AUTHORITY = (PCHAR + "\\[\\:\\]").freeze
+      AUTHORITY = (PCHAR + "\\[\\]").freeze
       PATH = (PCHAR + "\\/").freeze
       QUERY = (PCHAR + "\\/\\?").freeze
       FRAGMENT = (PCHAR + "\\/\\?").freeze
@@ -481,7 +481,7 @@ module Addressable
         leave_encoded.include?(c) ? sequence : c
       end
 
-      result.force_encoding("utf-8")
+      result.force_encoding(Encoding::UTF_8)
       if return_type == String
         return result
       elsif return_type == ::Addressable::URI
@@ -579,7 +579,7 @@ module Addressable
       unencoded = self.unencode_component(component, String, leave_encoded)
       begin
         encoded = self.encode_component(
-          Addressable::IDNA.unicode_normalize_kc(unencoded),
+          unencoded.unicode_normalize(:nfc),
           character_class,
           leave_encoded
         )
@@ -687,8 +687,7 @@ module Addressable
       components.each do |key, value|
         if value != nil
           begin
-            components[key] =
-              Addressable::IDNA.unicode_normalize_kc(value.to_str)
+            components[key] = value.to_str.unicode_normalize(:nfc)
           rescue ArgumentError
             # Likely a malformed UTF-8 character, skip unicode normalization
             components[key] = value.to_str

--- a/spec/addressable/idna_spec.rb
+++ b/spec/addressable/idna_spec.rb
@@ -38,6 +38,12 @@ shared_examples_for "converting from unicode to ASCII" do
     )).to eq("www.xn--8ws00zhy3a.com")
   end
 
+  it "also accepts unicode strings encoded as ascii-8bit" do
+    expect(Addressable::IDNA.to_ascii(
+      "www.詹姆斯.com".b
+    )).to eq("www.xn--8ws00zhy3a.com")
+  end
+
   it "should convert 'www.Iñtërnâtiônàlizætiøn.com' correctly" do
     "www.Iñtërnâtiônàlizætiøn.com"
     expect(Addressable::IDNA.to_ascii(
@@ -248,11 +254,6 @@ shared_examples_for "converting from ASCII to unicode" do
     expect(Addressable::IDNA.to_unicode(
       "example..host"
     )).to eq("example..host")
-  end
-
-  it "should normalize 'string' correctly" do
-    expect(Addressable::IDNA.unicode_normalize_kc(:'string')).to eq("string")
-    expect(Addressable::IDNA.unicode_normalize_kc("string")).to eq("string")
   end
 end
 

--- a/spec/addressable/template_spec.rb
+++ b/spec/addressable/template_spec.rb
@@ -1021,6 +1021,19 @@ describe Addressable::Template do
         )
       end
 
+      it "normalizes as unicode even with wrong encoding specified" do
+        template = subject.partial_expand("query" => "Cafe\u0301".b)
+        expect(template.pattern).to eq(
+          "http://example.com/{resource}/Caf%C3%A9/"
+        )
+      end
+
+      it "raises on invalid unicode input" do
+        expect {
+          subject.partial_expand("query" => "M\xE9thode".b)
+        }.to raise_error(ArgumentError, "invalid byte sequence in UTF-8")
+      end
+
       it "does not normalize unicode when byte semantics requested" do
         template = subject.partial_expand({"query" => "Cafe\u0301"}, nil, false)
         expect(template.pattern).to eq(
@@ -1079,6 +1092,17 @@ describe Addressable::Template do
       it "normalizes unicode by default" do
         uri = subject.expand("query" => "Cafe\u0301").to_str
         expect(uri).to eq("http://example.com/search/Caf%C3%A9/")
+      end
+
+      it "normalizes as unicode even with wrong encoding specified" do
+        uri = subject.expand("query" => "Cafe\u0301".b).to_str
+        expect(uri).to eq("http://example.com/search/Caf%C3%A9/")
+      end
+
+      it "raises on invalid unicode input" do
+        expect {
+          subject.expand("query" => "M\xE9thode".b).to_str
+        }.to raise_error(ArgumentError, "invalid byte sequence in UTF-8")
       end
 
       it "does not normalize unicode when byte semantics requested" do

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -5953,6 +5953,26 @@ describe Addressable::URI, "when normalizing a path with an encoded slash" do
   end
 end
 
+describe Addressable::URI, "when normalizing a path with special unicode" do
+  it "does not stop at or ignore null bytes" do
+    expect(Addressable::URI.parse("/path%00segment/").normalize.path).to eq(
+      "/path%00segment/"
+    )
+  end
+
+  it "does apply NFC unicode normalization" do
+    expect(Addressable::URI.parse("/%E2%84%A6").normalize.path).to eq(
+      "/%CE%A9"
+    )
+  end
+
+  it "does not apply NFKC unicode normalization" do
+    expect(Addressable::URI.parse("/%C2%AF%C2%A0").normalize.path).to eq(
+      "/%C2%AF%C2%A0"
+    )
+  end
+end
+
 describe Addressable::URI, "when normalizing a partially encoded string" do
   it "should result in correct percent encoded sequence" do
     expect(Addressable::URI.normalize_component(


### PR DESCRIPTION
This is a fix for #408 and the beginning of the simplification and modernization of the IDNA code. It does:
- Replaces `libidn` unicode normalize implementation by ruby's, to avoid the null terminated string problem and support more recent unicode versions.
- Replaces `Pure` unicode normalize by ruby's, to avoid hundreds of line of slow and legacy ruby code and support more recent unicode versions.

The result in terms of performance is the following (benchmark code commited, but needs to be run on master to measure the legacy "pure" code):
```
#              user     system      total        real
# pure     1.325948   0.000000   1.325948 (  1.326054)
# libidn   0.058067   0.000000   0.058067 (  0.058069)
# ruby     0.325062   0.000000   0.325062 (  0.325115)
```

The native ruby implementation is 5-6 times **slower** than `libidn`, but also 5 times **faster** than the existing `Pure` one.

Considering this is just a small part and the rest of the ruby code is more than one order of magnitude slower (doing a full `normalize` in the `simple.rb` benchmark for example takes 8.6 seconds for the same 100k iterations on my machine), I think this is more than enough, no need to try to shave off microseconds in the `unicode_normalize` code if the rest is a lot of ruby.

And we benefit from the native ruby function which is going to be maintained and improved.
Specs have been added to cover the problematic `\x00` case.