### PR TITLE
Update version, gemspec, and CHANGELOG for 2.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,22 @@
+# Addressable 2.8.2
+- Improve cache hits and JIT friendliness ([#486](https://github.com/sporkmonger/addressable/pull/486))
+- Improve code style and test coverage ([#482](https://github.com/sporkmonger/addressable/pull/482))
+- Ensure reset of deferred validation ([#481](https://github.com/sporkmonger/addressable/pull/481))
+- Resolve normalization differences between `IDNA::Native` and `IDNA::Pure` ([#408](https://github.com/sporkmonger/addressable/issues/408), [#492])
+- Remove redundant colon in `Addressable::URI::CharacterClasses::AUTHORITY` regex ([#438](https://github.com/sporkmonger/addressable/pull/438)) (accidentally reverted by [#449] merge but [added back](https://github.com/sporkmonger/addressable/pull/492#discussion_r1105125280) in [#492])
+
+[#492]: https://github.com/sporkmonger/addressable/pull/492
+
 # Addressable 2.8.1
 - refactor `Addressable::URI.normalize_path` to address linter offenses ([#430](https://github.com/sporkmonger/addressable/pull/430))
-- remove redundant colon in `Addressable::URI::CharacterClasses::AUTHORITY` regex ([#438](https://github.com/sporkmonger/addressable/pull/438))
 - update gemspec to reflect supported Ruby versions ([#466], [#464], [#463])
 - compatibility w/ public_suffix 5.x ([#466], [#465], [#460])
 - fixes "invalid byte sequence in UTF-8" exception when unencoding URLs containing non UTF-8 characters ([#459](https://github.com/sporkmonger/addressable/pull/459))
-- `Ractor` compatibility ([#449](https://github.com/sporkmonger/addressable/pull/449))
+- `Ractor` compatibility ([#449])
 - use the whole string instead of a single line for template match ([#431](https://github.com/sporkmonger/addressable/pull/431))
 - force UTF-8 encoding only if needed ([#341](https://github.com/sporkmonger/addressable/pull/341))
 
+[#449]: https://github.com/sporkmonger/addressable/pull/449
 [#460]: https://github.com/sporkmonger/addressable/pull/460
 [#463]: https://github.com/sporkmonger/addressable/pull/463
 [#464]: https://github.com/sporkmonger/addressable/pull/464

--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,8 @@ PKG_FILES = FileList[
     "tasks/**/*",
     "[A-Z]*", "Rakefile"
 ].exclude(/pkg/).exclude(/database\.yml/).
-  exclude(/Gemfile\.lock/).exclude(/[_\.]git$/)
+  exclude(/Gemfile\.lock/).exclude(/[_\.]git$/).
+  exclude(/coverage/)
 
 task :default => "spec"
 

--- a/addressable.gemspec
+++ b/addressable.gemspec
@@ -1,35 +1,28 @@
 # -*- encoding: utf-8 -*-
-# stub: addressable 2.8.1 ruby lib
+# stub: addressable 2.8.2 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "addressable".freeze
-  s.version = "2.8.1"
+  s.version = "2.8.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "changelog_uri" => "https://github.com/sporkmonger/addressable/blob/main/CHANGELOG.md" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Bob Aman".freeze]
-  s.date = "2022-08-19"
+  s.date = "2023-04-01"
   s.description = "Addressable is an alternative implementation to the URI implementation that is\npart of Ruby's standard library. It is flexible, offers heuristic parsing, and\nadditionally provides extensive support for IRIs and URI templates.\n".freeze
   s.email = "bob@sporkmonger.com".freeze
   s.extra_rdoc_files = ["README.md".freeze]
-  s.files = ["CHANGELOG.md".freeze, "Gemfile".freeze, "LICENSE.txt".freeze, "README.md".freeze, "Rakefile".freeze, "data/unicode.data".freeze, "lib/addressable".freeze, "lib/addressable.rb".freeze, "lib/addressable/idna".freeze, "lib/addressable/idna.rb".freeze, "lib/addressable/idna/native.rb".freeze, "lib/addressable/idna/pure.rb".freeze, "lib/addressable/template.rb".freeze, "lib/addressable/uri.rb".freeze, "lib/addressable/version.rb".freeze, "spec/addressable".freeze, "spec/addressable/idna_spec.rb".freeze, "spec/addressable/net_http_compat_spec.rb".freeze, "spec/addressable/security_spec.rb".freeze, "spec/addressable/template_spec.rb".freeze, "spec/addressable/uri_spec.rb".freeze, "spec/spec_helper.rb".freeze, "tasks/clobber.rake".freeze, "tasks/gem.rake".freeze, "tasks/git.rake".freeze, "tasks/metrics.rake".freeze, "tasks/profile.rake".freeze, "tasks/rspec.rake".freeze, "tasks/yard.rake".freeze]
+  s.files = ["CHANGELOG.md".freeze, "Gemfile".freeze, "LICENSE.txt".freeze, "README.md".freeze, "Rakefile".freeze, "addressable.gemspec".freeze, "benchmark".freeze, "data".freeze, "data/unicode.data".freeze, "gemfiles".freeze, "lib".freeze, "lib/addressable".freeze, "lib/addressable.rb".freeze, "lib/addressable/idna".freeze, "lib/addressable/idna.rb".freeze, "lib/addressable/idna/native.rb".freeze, "lib/addressable/idna/pure.rb".freeze, "lib/addressable/template.rb".freeze, "lib/addressable/uri.rb".freeze, "lib/addressable/version.rb".freeze, "spec".freeze, "spec/addressable".freeze, "spec/addressable/idna_spec.rb".freeze, "spec/addressable/net_http_compat_spec.rb".freeze, "spec/addressable/security_spec.rb".freeze, "spec/addressable/template_spec.rb".freeze, "spec/addressable/uri_spec.rb".freeze, "spec/spec_helper.rb".freeze, "tasks".freeze, "tasks/clobber.rake".freeze, "tasks/gem.rake".freeze, "tasks/git.rake".freeze, "tasks/metrics.rake".freeze, "tasks/profile.rake".freeze, "tasks/rspec.rake".freeze, "tasks/yard.rake".freeze]
   s.homepage = "https://github.com/sporkmonger/addressable".freeze
   s.licenses = ["Apache-2.0".freeze]
   s.rdoc_options = ["--main".freeze, "README.md".freeze]
   s.required_ruby_version = Gem::Requirement.new(">= 2.2".freeze)
-  s.rubygems_version = "3.3.7".freeze
+  s.rubygems_version = "3.4.8".freeze
   s.summary = "URI Implementation".freeze
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 4
-  end
+  s.specification_version = 4
 
-  if s.respond_to? :add_runtime_dependency then
-    s.add_runtime_dependency(%q<public_suffix>.freeze, [">= 2.0.2", "< 6.0"])
-    s.add_development_dependency(%q<bundler>.freeze, [">= 1.0", "< 3.0"])
-  else
-    s.add_dependency(%q<public_suffix>.freeze, [">= 2.0.2", "< 6.0"])
-    s.add_dependency(%q<bundler>.freeze, [">= 1.0", "< 3.0"])
-  end
+  s.add_runtime_dependency(%q<public_suffix>.freeze, [">= 2.0.2", "< 6.0"])
+  s.add_development_dependency(%q<bundler>.freeze, [">= 1.0", "< 3.0"])
 end

--- a/lib/addressable/version.rb
+++ b/lib/addressable/version.rb
@@ -23,7 +23,7 @@ if !defined?(Addressable::VERSION)
     module VERSION
       MAJOR = 2
       MINOR = 8
-      TINY  = 1
+      TINY  = 2
 
       STRING = [MAJOR, MINOR, TINY].join('.')
     end


### PR DESCRIPTION
Ran `bundle exec rake gem:gemspec` on Ruby 3.2.1 to update the gemspec.

Not sure why list of files changed, but it has happened before: https://github.com/sporkmonger/addressable/pull/466#discussion_r928663411

List extended this time with

    ["addressable.gemspec", "benchmark", "data", "gemfiles", "lib", "spec", "tasks"]

Changes: https://github.com/sporkmonger/addressable/compare/addressable-2.8.1...5c22f258c8acb6750ef6b1b0487ffcc1c3fdb874