### PR TITLE
restore unicode_normalize_kc as a deprecated method

### DIFF
--- a/benchmark/unicode_normalize.rb
+++ b/benchmark/unicode_normalize.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true.
 
 require "benchmark"
-require "addressable/idna/pure.rb"
+require_relative "../lib/addressable/idna/pure.rb"
 require "idn"
 
 value = "ﬁﾯリ宠퐱卄.com"

--- a/lib/addressable/idna/native.rb
+++ b/lib/addressable/idna/native.rb
@@ -29,6 +29,16 @@ module Addressable
        IDN::Punycode.decode(value.to_s)
      end
 
+    class << self
+      # @deprecated Use {String#unicode_normalize(:nfkc)} instead
+      def unicode_normalize_kc(value)
+        value.to_s.unicode_normalize(:nfkc)
+      end
+
+      extend Gem::Deprecate
+      deprecate :unicode_normalize_kc, "String#unicode_normalize(:nfkc)", 2023, 4
+    end
+
     def self.to_ascii(value)
       value.to_s.split('.', -1).map do |segment|
         if segment.size > 0 && segment.size < 64

--- a/lib/addressable/idna/pure.rb
+++ b/lib/addressable/idna/pure.rb
@@ -112,6 +112,16 @@ module Addressable
       output
     end
 
+    class << self
+      # @deprecated Use {String#unicode_normalize(:nfkc)} instead
+      def unicode_normalize_kc(value)
+        value.to_s.unicode_normalize(:nfkc)
+      end
+
+      extend Gem::Deprecate
+      deprecate :unicode_normalize_kc, "String#unicode_normalize(:nfkc)", 2023, 4
+    end
+
     ##
     # Unicode aware downcase method.
     #


### PR DESCRIPTION
As discussed in https://github.com/sporkmonger/addressable/pull/492#discussion_r1157346135, this is the PR to restore `unicode_normalize_kc` as a deprecated method (in case some people where using it). Example of the produced warning:
```
NOTE: Addressable::IDNA.unicode_normalize_kc is deprecated; use String#unicode_normalize(:nfkc) instead. It will be removed on or after 2023-04.
Addressable::IDNA.unicode_normalize_kc called from benchmark/unicode_normalize.rb:17.
```