### PR TITLE
Fix YAML serialization

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -2396,6 +2396,25 @@ module Addressable
       @validation_deferred = false
     end
 
+    def encode_with(coder)
+      instance_variables.each do |ivar|
+        value = instance_variable_get(ivar)
+        if value != NONE
+          key = ivar.to_s.slice(1..-1)
+          coder[key] = value
+        end
+      end
+      nil
+    end
+
+    def init_with(coder)
+      reset_ivs
+      coder.map.each do |key, value|
+        instance_variable_set("@#{key}", value)
+      end
+      nil
+    end
+
   protected
     SELF_REF = '.'
     PARENT = '..'

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -20,6 +20,7 @@ require "spec_helper"
 require "addressable/uri"
 require "uri"
 require "ipaddr"
+require "yaml"
 
 if !"".respond_to?("force_encoding")
   class String
@@ -6797,5 +6798,12 @@ describe Addressable::URI, "when deferring validation" do
   it "returns nil" do
     res = uri.defer_validation {}
     expect(res).to be nil
+  end
+end
+
+describe Addressable::URI, "YAML safe loading" do
+  it "doesn't serialize anonymous objects" do
+    url = Addressable::URI.parse("http://example.com/")
+    expect(YAML.dump(url)).to_not include("!ruby/object {}")
   end
 end


### PR DESCRIPTION
Ref: https://github.com/sporkmonger/addressable/pull/486

Following the introduction of `NONE` flags, `Addressable::URI` instance can no longer be correctly serialized with YAML.

It appear to work, but `NONE` is serialized as `!ruby/object {}`, so when the YAML is parsed back, the attributes are assigned a distinct anonymous object.

FYI: @tenderlove 