### PR TITLE
Add public_suffix method to allow users to access the PublicSuffix::Domain object easily.

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1198,7 +1198,7 @@ module Addressable
     # @example
     #   Addressable::URI.parse("http://www.example.co.uk").tld # => "co.uk"
     def tld
-      PublicSuffix.parse(self.host, ignore_private: true).tld
+      public_suffix.tld
     end
 
     ##
@@ -1216,7 +1216,16 @@ module Addressable
     # @example
     #   Addressable::URI.parse("http://www.example.co.uk").domain # => "example.co.uk"
     def domain
-      PublicSuffix.domain(self.host, ignore_private: true)
+      public_suffix.domain
+    end
+
+    ##
+    # Returns a PublicSuffix::Domain object for this host.
+    #
+    # @example
+    #   Addressable::URI.parse("http://www.example.org").public_suffix #=> #<PublicSuffix::Domain @sld="example", @tld="org", @trd="www">
+    def public_suffix(**kwargs)
+      PublicSuffix.parse(self.host, **{ignore_private: true}.merge(kwargs))
     end
 
     ##

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -6799,3 +6799,9 @@ describe Addressable::URI, "when deferring validation" do
     expect(res).to be nil
   end
 end
+
+describe Addressable::URI, "public suffix" do
+  it "should return a PublicSuffix::Domain object" do
+    expect(Addressable::URI.parse("http://example.org").public_suffix).to be_an(PublicSuffix::Domain)
+  end
+end


### PR DESCRIPTION
This exposes the `PublicSuffix::Domain` object so users can interact with that as needed. Plus it provides a consistent interface for Addressable::URI to interact with.

This is useful for accessing subdomains. PublicSuffix's `#trd` method returns `"www.test"` from `"www.test.example.org"`. 

I'd also like to add `subdomain` & `subdomains` methods to Addressable::URI for direct access to subdomains (which I have a follow up Pull Request for if this is accepted).