### PR TITLE
Fix gemspec generation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,12 +20,17 @@ additionally provides extensive support for IRIs and URI templates.
 TEXT
 
 PKG_FILES = FileList[
-    "lib/**/*", "spec/**/*", "vendor/**/*", "data/**/*",
-    "tasks/**/*",
-    "[A-Z]*", "Rakefile"
-].exclude(/pkg/).exclude(/database\.yml/).
-  exclude(/Gemfile\.lock/).exclude(/[_\.]git$/).
-  exclude(/coverage/)
+    "data/**/*",
+    "lib/**/*.rb",
+    "spec/**/*.rb",
+    "tasks/**/*.rake",
+    "addressable.gemspec",
+    "CHANGELOG.md",
+    "Gemfile",
+    "LICENSE.txt",
+    "README.md",
+    "Rakefile",
+]
 
 task :default => "spec"
 


### PR DESCRIPTION
This should resolve the issues (#495, #497) with the files list once for all. The main problem was probably the "[A-Z]*" glob matching lowercase files (and directories) when using a case-insensitive filesystem (typical for macOS).

Inspired by https://github.com/sporkmonger/addressable/commit/0a6f09194a66f07e0b095ce87c844848547d497a