### PR TITLE
gemspec: more `#freeze` and `rubygems_version` bump

### DIFF
--- a/addressable.gemspec
+++ b/addressable.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
   s.name = "addressable".freeze
-  s.version = "2.8.6"
+  s.version = "2.8.6".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "changelog_uri" => "https://github.com/sporkmonger/addressable/blob/main/CHANGELOG.md#v2.8.6" } if s.respond_to? :metadata=
@@ -18,11 +18,11 @@ Gem::Specification.new do |s|
   s.licenses = ["Apache-2.0".freeze]
   s.rdoc_options = ["--main".freeze, "README.md".freeze]
   s.required_ruby_version = Gem::Requirement.new(">= 2.2".freeze)
-  s.rubygems_version = "3.4.18".freeze
+  s.rubygems_version = "3.4.22".freeze
   s.summary = "URI Implementation".freeze
 
   s.specification_version = 4
 
-  s.add_runtime_dependency(%q<public_suffix>.freeze, [">= 2.0.2", "< 6.0"])
-  s.add_development_dependency(%q<bundler>.freeze, [">= 1.0", "< 3.0"])
+  s.add_runtime_dependency(%q<public_suffix>.freeze, [">= 2.0.2".freeze, "< 6.0".freeze])
+  s.add_development_dependency(%q<bundler>.freeze, [">= 1.0".freeze, "< 3.0".freeze])
 end


### PR DESCRIPTION
This diff appeared after I ran

    VERSION=2.8.6 bundle exec rake gem:release

And the task stopped midway, at https://github.com/sporkmonger/addressable/blob/63ab40ec2788c9879753bb15b1252b88c6ad0a62/tasks/git.rake#L26