### PR TITLE
Add bigdecimal to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
+  gem 'bigdecimal' if RUBY_VERSION > '2.4'
   gem 'rspec', '~> 3.8'
   gem 'rspec-its', '~> 1.3'
 end


### PR DESCRIPTION
From Ruby 3.4 onwards, gems that are expected to become bundled gems will raise a LoadError if they are required without being present in the Gemfile or gemspec. Therefore, I have added the target gem to the Gemfile.

```sh
/addressable/spec/addressable/template_spec.rb:20: warning: bigdecimal was loaded from the standard library, but is not part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec.

An error occurred while loading ./spec/addressable/template_spec.rb. - Did you mean?
                    rspec ./spec/addressable/idna_spec.rb
                    rspec ./spec/addressable/uri_spec.rb
                    rspec ./spec/addressable/security_spec.rb

Failure/Error: require "bigdecimal"

LoadError:
  cannot load such file -- bigdecimal
# ./spec/addressable/template_spec.rb:20:in '<top (required)>'
```