### PR TITLE
Use Ubuntu 20.04 in trusted publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     if: github.repository == 'sporkmonger/addressable'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       id-token: write # for trusted publishing
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,17 @@ on:
 jobs:
   release:
     if: github.repository == 'sporkmonger/addressable'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write # for trusted publishing
     steps:
       # tags are named addressable-VERSION, e.g. addressable-2.8.6
       - name: Set VERSION from git tag
         run: echo "VERSION=$(echo ${{ github.ref }} | cut -d - -f 2)" >> "$GITHUB_ENV"
+
+      - name: Install libidn
+        if: startsWith(matrix.os, 'ubuntu')
+        run: sudo apt-get install libidn11-dev
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The release workflow ran on ubuntu-22.04 with Ruby 3.3.3 and failed, we haven't tested that combo yet.

Hopefully this works as we do test on ubuntu-20.04 and Ruby 3.3.