### PR TITLE
CI: remove `macos-11` job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,6 @@ jobs:
           # Ubuntu
           - { os: ubuntu-22.04, ruby: 3.1 }
           # macOS
-          - { os: macos-11,     ruby: 3.1 }
           - { os: macos-12,     ruby: 3.1 }
           # Windows
           - { os: windows-2019, ruby: 3.1 }


### PR DESCRIPTION
> The macos-11 label has been deprecated and will no longer be available
> after 28 June 2024.

Close #540