### PR TITLE
Fixed `Addressable::URI#inspect` to use `self.class`.

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -2382,7 +2382,7 @@ module Addressable
     #
     # @return [String] The URI object's state, as a <code>String</code>.
     def inspect
-      sprintf("#<%s:%#0x URI:%s>", URI.to_s, self.object_id, self.to_s)
+      sprintf("#<%s:%#0x URI:%s>", self.class.to_s, self.object_id, self.to_s)
     end
 
     ##

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -1757,6 +1757,19 @@ describe Addressable::URI, "when parsed from " +
     expect(@uri.inspect).to include("%#0x" % @uri.object_id)
   end
 
+  context "when Addressable::URI has been sub-classed" do
+    class CustomURIClass < Addressable::URI
+    end
+
+    before do
+      @uri = CustomURIClass.parse("http://example.com")
+    end
+
+    it "when inspected, should have the sub-classes name" do
+      expect(@uri.inspect).to include("CustomURIClass")
+    end
+  end
+
   it "should use the 'http' scheme" do
     expect(@uri.scheme).to eq("http")
   end


### PR DESCRIPTION
This will allow sub-classing `Addressable::URI` and have the sub-classes name show up in the `inspect` output.

```ruby
class CustomURL < Addressable::URI

  def custom_method
     ...
  end

end

uri = CustomURL.parse("https://example.com")
# => #<CustomURL:0x1824 URI:https://example.com>
```