### PR TITLE
fix(uri): query_value guetter - return all elements in array not just last value

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1693,7 +1693,7 @@ module Addressable
           pair[1] = URI.unencode_component(value)
         end
         if return_type == Hash
-          accu[pair[0]] = pair[1]
+          accu[pair[0]] = accu.key?(pair[0]) ? [accu[pair[0]], pair[1]].flatten : pair[1]
         else
           accu << pair
         end

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -5088,15 +5088,9 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have correct hash query values" do
-    skip("This is probably more desirable behavior.")
     expect(@uri.query_values(Hash)).to eq(
-      {'one' => ['two', 'three', 'four']}
-      )
-  end
-
-  it "should handle assignment with keys of mixed type" do
-    @uri.query_values = @uri.query_values(Hash).merge({:one => 'three'})
-    expect(@uri.query_values(Hash)).to eq({'one' => 'three'})
+      { 'one' => ['two', 'three', 'four'] }
+    )
   end
 end
 
@@ -5109,7 +5103,7 @@ describe Addressable::URI, "when parsed from " +
   end
 
   it "should have correct query values" do
-    expect(@uri.query_values(Hash)).to eq({"one[two][three][]" => "five"})
+    expect(@uri.query_values(Hash)).to eq({"one[two][three][]" => ["four", "five"]})
   end
 
   it "should have correct array query values" do


### PR DESCRIPTION
Hi, 

I have a problem when i want to use `query_values`.
When a query params is an array this lib return only the last element 

```ruby
uri = Addressable::URI.parse("http://my_url.com?param=a&param=b")
uri.query_values 
=> {
  param: "b"
}
```

but I think it better if it return all values in array like that :

```ruby
uri = Addressable::URI.parse("http://my_url.com?param=a&param=b")
uri.query_values 
=> {
  param: ["a", "b"]
}
```

So i propose an implementation for this problem

Thank's