### PR TITLE
CI: `ubuntu-20.04` -> `ubuntu-22.04`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,7 @@ jobs:
           # Ubuntu
           - { os: ubuntu-22.04, ruby: 3.1 }
           # macOS
-          - { os: macos-12,     ruby: 3.1 }
+          - { os: macos-13,     ruby: 3.1 }
           # Windows
           - { os: windows-2019, ruby: 3.1 }
           - { os: windows-2022, ruby: 3.1 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,6 @@ jobs:
       matrix:
         # the job name is composed by these attributes
         ruby:
-          - 2.2
           - 2.3
           - 2.4
           - 2.5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,6 @@ jobs:
           - jruby-9.2
           - jruby-9.3
           - jruby-9.4
-          - truffleruby-22.1
           - truffleruby-22.2
           - truffleruby-22.3
         os:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         ruby: [2.7]
         idna_mode: [native, pure]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     env:
       IDNA_MODE: ${{ matrix.idna_mode }}
     steps:
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [2.7]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     env:
       BUNDLE_WITHOUT: development
       COVERALLS_SERVICE_NAME: github
@@ -97,13 +97,13 @@ jobs:
           - truffleruby-22.2
           - truffleruby-22.3
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
         gemfile:
           - Gemfile
         include:
-          - { os: ubuntu-20.04, ruby: 2.7, gemfile: gemfiles/public_suffix_2.rb }
-          - { os: ubuntu-20.04, ruby: 2.7, gemfile: gemfiles/public_suffix_3.rb }
-          - { os: ubuntu-20.04, ruby: 2.7, gemfile: gemfiles/public_suffix_4.rb }
+          - { os: ubuntu-22.04, ruby: 2.7, gemfile: gemfiles/public_suffix_2.rb }
+          - { os: ubuntu-22.04, ruby: 2.7, gemfile: gemfiles/public_suffix_3.rb }
+          - { os: ubuntu-22.04, ruby: 2.7, gemfile: gemfiles/public_suffix_4.rb }
           # Ubuntu
           - { os: ubuntu-22.04, ruby: 3.1 }
           # macOS
@@ -113,9 +113,9 @@ jobs:
           - { os: windows-2022, ruby: 3.1 }
           - { os: windows-2022, ruby: jruby-9.3 }
           # allowed to fail
-          - { os: ubuntu-20.04, ruby: head, gemfile: Gemfile, allow-failure: true }
-          - { os: ubuntu-20.04, ruby: jruby-head, gemfile: Gemfile, allow-failure: true }
-          - { os: ubuntu-20.04, ruby: truffleruby-head, gemfile: Gemfile, allow-failure: true }
+          - { os: ubuntu-22.04, ruby: head, gemfile: Gemfile, allow-failure: true }
+          - { os: ubuntu-22.04, ruby: jruby-head, gemfile: Gemfile, allow-failure: true }
+          - { os: ubuntu-22.04, ruby: truffleruby-head, gemfile: Gemfile, allow-failure: true }
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
       BUNDLE_WITHOUT: development:coverage


### PR DESCRIPTION
Ubuntu 20.04 on GitHub Actions is deprecated, stops working 2025-04-01: https://github.com/actions/runner-images/issues/11101