### PR TITLE
idna/pure: stop building the useless `COMPOSITION_TABLE`

### DIFF
--- a/lib/addressable/idna/pure.rb
+++ b/lib/addressable/idna/pure.rb
@@ -4384,16 +4384,6 @@ module Addressable
       65518 => [0, 0, nil, "○", nil, nil, nil],
     }
 
-    COMPOSITION_TABLE = {}
-    UNICODE_DATA.each do |codepoint, data|
-      canonical = data[UNICODE_DATA_CANONICAL]
-      exclusion = data[UNICODE_DATA_EXCLUSION]
-
-      if canonical && exclusion == 0
-        COMPOSITION_TABLE[canonical.unpack("C*")] = codepoint
-      end
-    end
-
     UNICODE_MAX_LENGTH = 256
     ACE_MAX_LENGTH = 256
 


### PR DESCRIPTION
Nothing references it since 1998e06c81d813eac30409497b04fc6d6f19d231

This saves ~150kiB and a bit of CPU at boot time.

