### PR TITLE
Autoload all Addressable modules to avoid segfaults on load

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Addressable closely conforms to RFC 3986, RFC 3987, and RFC 6570 (level 4).
 ## Example usage
 
 ```ruby
-require "addressable/uri"
+require "addressable"
 
 uri = Addressable::URI.parse("http://example.com/path/to/resource/")
 uri.scheme
@@ -55,8 +55,7 @@ For more details, see [RFC 6570](https://www.rfc-editor.org/rfc/rfc6570.txt).
 
 
 ```ruby
-
-require "addressable/template"
+require "addressable"
 
 template = Addressable::Template.new("http://example.com/{?query*}")
 template.expand({

--- a/lib/addressable.rb
+++ b/lib/addressable.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
-require 'addressable/uri'
-require 'addressable/template'
+module Addressable
+  autoload :VERSION, File.expand_path("addressable/version", __dir__)
+  autoload :IDNA, File.expand_path("addressable/idna", __dir__)
+  autoload :URI, File.expand_path("addressable/uri", __dir__)
+  autoload :Template, File.expand_path("addressable/template", __dir__)
+end

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -16,9 +16,12 @@
 #    limitations under the License.
 #++
 
-
-require "addressable/version"
-require "addressable/uri"
+# Maintain backwards compatibility for code that uses
+# `require "addressable/template"` as a direct entrypoint. When loaded via
+# `require "addressable"`, autoloads handle these dependencies instead.
+# This can be removed in a future major/minor version bump.
+require "addressable/version" unless defined?(Addressable::VERSION)
+require "addressable/uri" unless defined?(Addressable::URI)
 
 module Addressable
   ##

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -17,8 +17,13 @@
 #++
 
 
-require "addressable/version"
-require "addressable/idna"
+# Maintain backwards compatibility for code that uses
+# `require "addressable/uri"` as a direct entrypoint. When loaded via
+# `require "addressable"`, autoloads handle these dependencies instead.
+# This can be removed in a future major/minor version bump.
+require "addressable/version" unless defined?(Addressable::VERSION)
+require "addressable/idna" unless defined?(Addressable::IDNA)
+
 require "public_suffix"
 
 ##


### PR DESCRIPTION
## Summary

- **Problem:** `require "addressable"` eagerly loads all modules, including `idna/pure.rb` (~4,700 lines of Unicode mapping tables). On some Ruby versions/platforms this causes [segfaults](https://github.com/sporkmonger/addressable/issues?q=segfault) — even when the application never performs IDN operations.
- **Fix:** Replace all eager `require` calls with `autoload` for `VERSION`, `URI`, `Template`, and `IDNA`. Modules are only loaded when first accessed.

## Changes

- `lib/addressable.rb` — Replace eager requires with `autoload` for all four top-level constants (`VERSION`, `IDNA`, `URI`, `Template`).
- `lib/addressable/uri.rb` — Add backwards-compat guards that eagerly require `version` and `idna` only when not already defined/autoloaded.
- `lib/addressable/template.rb` — Same guards for `version` and `uri`.
- `README.md` — Update examples to use `require "addressable"`.

## Backwards compatibility

The recommended entrypoint is now `require "addressable"`, which sets up autoloads so only the modules you use get loaded. The old entrypoints (`require "addressable/uri"`, `require "addressable/template"`) still work in any load order — they check for specific constants (e.g., `defined?(Addressable::IDNA)`) and only require what's missing. These fallback guards can be removed in a future major/minor version bump at the maintainer's discretion.

## Test plan

- [x] `require "addressable"` — autoloads all modules on demand
- [x] `require "addressable/uri"` — works as a standalone entrypoint
- [x] `require "addressable/template"` — works as a standalone entrypoint
- [x] `require "addressable/uri"` then `require "addressable/template"` — works
- [x] `require "addressable/template"` then `require "addressable/uri"` — works
- [x] URI parsing, IDN normalization, and template expansion all work across all entrypoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)