### PR TITLE
Preserve percent-encoded reserved characters during normalization

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -63,10 +63,7 @@ module Addressable
     module NormalizeCharacterClasses
       HOST = /[^#{CharacterClasses::HOST}]/
       UNRESERVED = /[^#{CharacterClasses::UNRESERVED}]/
-      PCHAR = /[^#{CharacterClasses::PCHAR}]/
       SCHEME = /[^#{CharacterClasses::SCHEME}]/
-      FRAGMENT = /[^#{CharacterClasses::FRAGMENT}]/
-      QUERY = %r{[^a-zA-Z0-9\-\.\_\~\!\$\'\(\)\*\+\,\=\:\@\/\?%]|%(?!2B|2b)}
     end
 
     module CharacterClassesRegexps
@@ -591,7 +588,7 @@ module Addressable
           leave_encoded
         )
       rescue ArgumentError
-        encoded = self.encode_component(unencoded)
+        encoded = self.encode_component(unencoded, character_class, leave_encoded)
       end
       encoded.force_encoding(Encoding::UTF_8)
       return encoded
@@ -687,9 +684,6 @@ module Addressable
         :password => self.unencode_component(uri_object.password),
         :host => self.unencode_component(uri_object.host),
         :port => (uri_object.port.nil? ? nil : uri_object.port.to_s),
-        :path => self.unencode_component(uri_object.path),
-        :query => self.unencode_component(uri_object.query),
-        :fragment => self.unencode_component(uri_object.fragment)
       }
       components.each do |key, value|
         if value != nil
@@ -701,6 +695,7 @@ module Addressable
           end
         end
       end
+      reserved_chars = Addressable::URI::CharacterClasses::RESERVED.delete("\\")
       encoded_uri = Addressable::URI.new(
         :scheme => self.encode_component(components[:scheme],
           Addressable::URI::CharacterClassesRegexps::SCHEME),
@@ -710,12 +705,12 @@ module Addressable
           Addressable::URI::CharacterClassesRegexps::UNRESERVED),
         :host => components[:host],
         :port => components[:port],
-        :path => self.encode_component(components[:path],
-          Addressable::URI::CharacterClassesRegexps::PATH),
-        :query => self.encode_component(components[:query],
-          Addressable::URI::CharacterClassesRegexps::QUERY),
-        :fragment => self.encode_component(components[:fragment],
-          Addressable::URI::CharacterClassesRegexps::FRAGMENT)
+        :path => self.normalize_component(uri_object.path,
+          Addressable::URI::CharacterClasses::PATH, reserved_chars),
+        :query => self.normalize_component(uri_object.query,
+          Addressable::URI::CharacterClasses::QUERY, reserved_chars),
+        :fragment => self.normalize_component(uri_object.fragment,
+          Addressable::URI::CharacterClasses::FRAGMENT, reserved_chars)
       )
       if return_type == String
         return encoded_uri.to_s
@@ -1541,10 +1536,12 @@ module Addressable
         end
         # String#split(delimiter, -1) uses the more strict splitting behavior
         # found by default in Python.
+        reserved_chars = Addressable::URI::CharacterClasses::RESERVED.delete("\\")
         result = path.strip.split(SLASH, -1).map do |segment|
           Addressable::URI.normalize_component(
             segment,
-            Addressable::URI::NormalizeCharacterClasses::PCHAR
+            Addressable::URI::CharacterClasses::PCHAR,
+            reserved_chars
           )
         end.join(SLASH)
 
@@ -1617,14 +1614,16 @@ module Addressable
         modified_query_class = Addressable::URI::CharacterClasses::QUERY.dup
         # Make sure possible key-value pair delimiters are escaped.
         modified_query_class.sub!("\\&", "").sub!("\\;", "")
-        pairs = (query || "").split("&", -1)
+        leave_encoded =
+          Addressable::URI::CharacterClasses::RESERVED.delete("\\") + "+"
+        pairs = query.split("&", -1)
         pairs.delete_if(&:empty?).uniq! if flags.include?(:compacted)
         pairs.sort! if flags.include?(:sorted)
         component = pairs.map do |pair|
           Addressable::URI.normalize_component(
             pair,
-            Addressable::URI::NormalizeCharacterClasses::QUERY,
-            "+"
+            modified_query_class,
+            leave_encoded
           )
         end.join("&")
         component == "" ? nil : component
@@ -1819,7 +1818,8 @@ module Addressable
       @normalized_fragment = begin
         component = Addressable::URI.normalize_component(
           self.fragment,
-          Addressable::URI::NormalizeCharacterClasses::FRAGMENT
+          Addressable::URI::CharacterClasses::FRAGMENT,
+          Addressable::URI::CharacterClasses::RESERVED.delete("\\")
         )
         component == "" ? nil : component
       end

--- a/spec/addressable/uri_spec.rb
+++ b/spec/addressable/uri_spec.rb
@@ -2704,6 +2704,34 @@ describe Addressable::URI, "when parsed from " +
   end
 end
 
+# RFC 3986, section 6.2.2.2: only unreserved characters may be decoded during normalization
+describe Addressable::URI, "when normalizing URIs with percent-encoded reserved characters" do
+  def self.it_normalizes(input, expected)
+    it "normalizes #{input.inspect} to #{expected.inspect}" do
+      expect(Addressable::URI.normalized_encode(input)).to eq(expected)
+      expect(Addressable::URI.parse(input).normalize.to_s).to eq(expected)
+    end
+  end
+
+  it_normalizes(
+    "http://example.com/%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D/:@!$&'()*+,;=",
+    "http://example.com/%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D/:@!$&'()*+,;="
+  )
+
+  it_normalizes(
+    "http://example.com/?%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D&raw=:/?@!$'()*+,=",
+    "http://example.com/?%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D&raw=:/?@!$'()*+,="
+  )
+
+  it_normalizes(
+    "http://example.com/#%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D/raw=:/?@!$&'()*+,;=",
+    "http://example.com/#%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D/raw=:/?@!$&'()*+,;="
+  )
+
+  # Positive control: unreserved characters should still be decoded.
+  it_normalizes("http://example.com/%41%42%43", "http://example.com/ABC")
+end
+
 describe Addressable::URI, "when parsed from " +
     "'http://example.com/?q=string'" do
   before do
@@ -4472,8 +4500,10 @@ describe Addressable::URI, "when parsed from " +
     @uri = Addressable::URI.parse("http://example.com/sound%2bvision")
   end
 
-  it "should have a normalized path of '/sound+vision'" do
-    expect(@uri.normalized_path).to eq('/sound+vision')
+  it "should have a normalized path of '/sound%2Bvision'" do
+    # `+` is a sub-delim (reserved per RFC 3986 §2.2), so `%2B` and `+` are
+    # not equivalent and the percent-encoded form must be preserved.
+    expect(@uri.normalized_path).to eq('/sound%2Bvision')
   end
 end
 


### PR DESCRIPTION
RFC 3986 section 2.2 states that a reserved character and its percent-encoded form are not equivalent, and section 6.2.2.2 only permits decoding unreserved characters during normalization.

Previously decoding and re-encoding URLs was turning `%3A` into `:`, `%2F` into `/`, etc.

Both normalization methods (`URI.normalized_encode` and `URI#normalize`) now pass the reserved characters to `normalize_component`. Decoding of unreserved characters is unchanged.

---

**NOTE: This is considered a breaking change.**

If anyone depended on percent-encoded reserved characters, they'll now have a different output. (more "correct" but still) Also, not public/not documented constants `PCHAR`, `FRAGMENT`, `QUERY` are removed since they're no longer used internally. (fwiw I didn't find any references to those in public repos on github)

---

Fixes #472
Fixes #424
Fixes #386
Fixes #366
Fixes #295