### PR TITLE
Make template hashes consistent with equality

### DIFF
--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -285,6 +285,12 @@ module Addressable
     alias_method :eql?, :==
 
     ##
+    # @return [Integer] A hash consistent with template equality.
+    def hash
+      self.pattern.hash
+    end
+
+    ##
     # Extracts a mapping from the URI using a URI Template pattern.
     #
     # @param [Addressable::URI, #to_str] uri


### PR DESCRIPTION
## Summary

Equal templates inherited Object identity hashes, so Hash/Set did not recognize an eql? template. Use the immutable pattern's hash, consistent with existing equality.

## Reproduction

```ruby
require 'addressable'
a = Addressable::Template.new('/{x}')
b = Addressable::Template.new('/{x}')
p [a.eql?(b), {a => :found}[b]]
# Before: [true, nil]; after: [true, :found]
```

## Verification

- Ruby 4.0.6 through rbenv; existing suite: **1,433 examples / 0 failures / 5 existing pending** with pure Ruby IDNA, **1,466 examples / 0 failures / 5 existing pending** with idn-ruby 0.1.5 + libidn.
- 16 focused external assertions pass on this individual patch; the combined installed-release branch also passes all focused cases and both existing suites.
- Comparative RuboCop Lint: 15 existing offenses before and after; no new offense (line references move). Syntax and git diff --check pass.

## Compatibility and limitations

Equal templates now share hash keys as required by eql?. Numeric hash values are not a persistence format.

No dependency/version/data updates. No repository tests were added or changed: the commissioning repository explicitly prohibits new/modified tests, so reproduction checks run outside this repository. Other Ruby versions/platforms were not run locally; upstream CI may require maintainer approval. The existing normalization proposal #589 and IDNA2008 proposal #496 are separate and unchanged.
