### PR TITLE
Preserve input arrays during template normalization

### DIFF
--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -900,7 +900,7 @@ module Addressable
     def normalize_value(value)
       # Handle unicode normalization
       if value.respond_to?(:to_ary)
-        value.to_ary.map! { |val| normalize_value(val) }
+        value = value.to_ary.map { |val| normalize_value(val) }
       elsif value.kind_of?(Hash)
         value = value.inject({}) { |acc, (k, v)|
           acc[normalize_value(k)] = normalize_value(v)


### PR DESCRIPTION
## Summary

Copy array values during Unicode normalization instead of mutating the caller's arrays. This accepts frozen arrays and also uses the converted array for to_ary objects.

## Reproduction

```ruby
require 'addressable'
values = ["e\u0301"].freeze
p Addressable::Template.new('/{x}').expand(x: values).to_s
# Before: FrozenError; after: /%C3%A9
```

## Verification

- Ruby 4.0.6 through rbenv; existing suite: **1,433 examples / 0 failures / 5 existing pending** with pure Ruby IDNA, **1,466 examples / 0 failures / 5 existing pending** with idn-ruby 0.1.5 + libidn.
- 11 focused external assertions pass on this individual patch; the combined installed-release branch also passes all focused cases and both existing suites.
- Comparative RuboCop Lint: 15 existing offenses before and after; no new offense (line references move). Syntax and git diff --check pass.

## Compatibility and limitations

No intended breaking change. Callers should not rely on expansion mutating their input arrays; normalization and generated output remain unchanged for existing supported values. Nested URI-template values are not newly supported.

No dependency/version/data updates. No repository tests were added or changed: the commissioning repository explicitly prohibits new/modified tests, so reproduction checks run outside this repository. Other Ruby versions/platforms were not run locally; upstream CI may require maintainer approval. The existing normalization proposal #589 and IDNA2008 proposal #496 are separate and unchanged.
