### PR TITLE
Split assigned userinfo at its first colon

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1094,7 +1094,7 @@ module Addressable
       end
       new_user, new_password = if new_userinfo
         [
-          new_userinfo.to_str.strip[/^(.*):/, 1],
+          new_userinfo.to_str.strip[/^([^:]*):?/, 1],
           new_userinfo.to_str.strip[/:(.*)$/, 1]
         ]
       else


### PR DESCRIPTION
## Summary

Make userinfo= use the same first-colon username split as URI.parse and authority=. Username-only values were dropped, and multi-colon passwords duplicated part of the password into the username.

## Reproduction

```ruby
require 'addressable'
uri = Addressable::URI.parse('https://example.com')
uri.userinfo = 'alice:one:two'
p [uri.user, uri.password]
# Before: [alice:one, one:two]; after: [alice, one:two]
uri.userinfo = 'alice'
p uri.user # Before nil; after alice
```

## Verification

- Ruby 4.0.6 through rbenv; existing suite: **1,433 examples / 0 failures / 5 existing pending** with pure Ruby IDNA, **1,466 examples / 0 failures / 5 existing pending** with idn-ruby 0.1.5 + libidn.
- 14 focused external assertions pass on this individual patch; the combined installed-release branch also passes all focused cases and both existing suites.
- Comparative RuboCop Lint: 15 existing offenses before and after; no new offense (line references move). Syntax and git diff --check pass.

## Compatibility and limitations

Corrects previously incorrect assigned user/password values. Empty passwords, nil clearing, trimming, percent-encoded colons and parsing conventions are retained.

No dependency/version/data updates. No repository tests were added or changed: the commissioning repository explicitly prohibits new/modified tests, so reproduction checks run outside this repository. Other Ruby versions/platforms were not run locally; upstream CI may require maintainer approval. The existing normalization proposal #589 and IDNA2008 proposal #496 are separate and unchanged.
