### PR TITLE
Decode form query keys consistently with values

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1675,6 +1675,9 @@ module Addressable
         raise ArgumentError, "Invalid return type. Must be Hash or Array."
       end
       return nil if self.query == nil
+      query_scheme = normalized_scheme
+      form_encoded = query_scheme.nil? ||
+        query_scheme == "http" || query_scheme == "https"
       split_query = self.query.split("&").map do |pair|
         pair.split("=", 2) if pair && !pair.empty?
       end.compact
@@ -1682,8 +1685,9 @@ module Addressable
         # I'd rather use key/value identifiers instead of array lookups,
         # but in this case I really want to maintain the exact pair structure,
         # so it's best to make all changes in-place.
-        form_encoded = ["http", "https", nil].include?(normalized_scheme)
-        pair[0] = URI.unencode_component(form_encoded ? pair[0].tr("+", " ") : pair[0])
+        key = pair[0]
+        key = key.tr("+", " ") if form_encoded
+        pair[0] = URI.unencode_component(key)
         if pair[1].respond_to?(:to_str)
           value = pair[1].to_str
           # I loathe the fact that I have to do this. Stupid HTML 4.01.

--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1682,14 +1682,15 @@ module Addressable
         # I'd rather use key/value identifiers instead of array lookups,
         # but in this case I really want to maintain the exact pair structure,
         # so it's best to make all changes in-place.
-        pair[0] = URI.unencode_component(pair[0])
+        form_encoded = ["http", "https", nil].include?(normalized_scheme)
+        pair[0] = URI.unencode_component(form_encoded ? pair[0].tr("+", " ") : pair[0])
         if pair[1].respond_to?(:to_str)
           value = pair[1].to_str
           # I loathe the fact that I have to do this. Stupid HTML 4.01.
           # Treating '+' as a space was just an unbelievably bad idea.
           # There was nothing wrong with '%20'!
           # If it ain't broke, don't fix it!
-          value = value.tr("+", " ") if ["http", "https", nil].include?(scheme)
+          value = value.tr("+", " ") if form_encoded
           pair[1] = URI.unencode_component(value)
         end
         if return_type == Hash


### PR DESCRIPTION
## Summary

Decode form-style '+' consistently in query keys and values, while leaving encoded %2B as a literal plus. Use normalized scheme comparison so HTTP/HTTPS casing does not change decoding. Other schemes retain literal plus behavior.

## Reproduction

```ruby
require 'addressable'
p Addressable::URI.parse('https://example.com?a+b=c+d').query_values
# Before: {a+b => c d}; after: {a b => c d}
```

## Verification

- Ruby 4.0.6 through rbenv; existing suite: **1,433 examples / 0 failures / 5 existing pending** with pure Ruby IDNA, **1,466 examples / 0 failures / 5 existing pending** with idn-ruby 0.1.5 + libidn.
- 14 focused external assertions pass on this individual patch; the combined installed-release branch also passes all focused cases and both existing suites.
- Comparative RuboCop Lint: 15 existing offenses before and after; no new offense (line references move). Syntax and git diff --check pass.

## Compatibility and limitations

Behavior correction: unescaped '+' in HTTP(S)/relative query keys now means a space, consistent with values. Use %2B for a literal plus. Uppercase HTTP(S) now follows the same rule; mailto and FTP remain unchanged.

No dependency/version/data updates. No repository tests were added or changed: the commissioning repository explicitly prohibits new/modified tests, so reproduction checks run outside this repository. Other Ruby versions/platforms were not run locally; upstream CI may require maintainer approval. The existing normalization proposal #589 and IDNA2008 proposal #496 are separate and unchanged.
