### PR TITLE
Keep query normalization flags out of the default cache

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1612,11 +1612,8 @@ module Addressable
     # @return [String] The query component, normalized.
     def normalized_query(*flags)
       return nil unless self.query
-      return @normalized_query unless @normalized_query == NONE
-      @normalized_query = begin
-        modified_query_class = Addressable::URI::CharacterClasses::QUERY.dup
-        # Make sure possible key-value pair delimiters are escaped.
-        modified_query_class.sub!("\\&", "").sub!("\\;", "")
+      return @normalized_query if flags.empty? && @normalized_query != NONE
+      normalized_query = begin
         pairs = (query || "").split("&", -1)
         pairs.delete_if(&:empty?).uniq! if flags.include?(:compacted)
         pairs.sort! if flags.include?(:sorted)
@@ -1630,8 +1627,9 @@ module Addressable
         component == "" ? nil : component
       end
       # All normalized values should be UTF-8
-      force_utf8_encoding_if_needed(@normalized_query)
-      @normalized_query
+      force_utf8_encoding_if_needed(normalized_query)
+      @normalized_query = normalized_query if flags.empty?
+      normalized_query
     end
 
     ##


### PR DESCRIPTION
## Summary

Keep the no-flag normalized query cache separate from flagged transformations. Previously whichever call ran first determined every later result. Flagged calls compute their requested result without mutating the default cache; remove the unused character-class temporary.

## Reproduction

```ruby
require 'addressable'
uri = Addressable::URI.parse('https://example.com?b=2&a=1')
p uri.normalized_query
p uri.normalized_query(:sorted)
# Before second result: b=2&a=1; after: a=1&b=2
```

## Verification

- Ruby 4.0.6 through rbenv; existing suite: **1,433 examples / 0 failures / 5 existing pending** with pure Ruby IDNA, **1,466 examples / 0 failures / 5 existing pending** with idn-ruby 0.1.5 + libidn.
- 722 focused external assertions pass on this individual patch; the combined installed-release branch also passes all focused cases and both existing suites.
- Comparative RuboCop Lint: 15 existing offenses before and after; no new offense (line references move). Syntax and git diff --check pass.

## Compatibility and limitations

No intended breaking change. sorted/compacted requests no longer overwrite default normalization. Repeated flagged calls are recomputed; no new unbounded cache. Frozen URIs remain usable.

No dependency/version/data updates. No repository tests were added or changed: the commissioning repository explicitly prohibits new/modified tests, so reproduction checks run outside this repository. Other Ruby versions/platforms were not run locally; upstream CI may require maintainer approval. The existing normalization proposal #589 and IDNA2008 proposal #496 are separate and unchanged.
