### PR TITLE
Preserve trailing empty labels in pure Ruby IDNA conversions

### DIFF
--- a/lib/addressable/idna/pure.rb
+++ b/lib/addressable/idna/pure.rb
@@ -66,7 +66,7 @@ module Addressable
         input.force_encoding(Encoding::ASCII_8BIT)
       end
       if input =~ UTF8_REGEX && input =~ UTF8_REGEX_MULTIBYTE
-        parts = unicode_downcase(input).split('.')
+        parts = unicode_downcase(input).split('.', -1)
         parts.map! do |part|
           if part.respond_to?(:force_encoding)
             part.force_encoding(Encoding::ASCII_8BIT)
@@ -87,7 +87,7 @@ module Addressable
     # domain name as described in RFC 3490.
     def self.to_unicode(input)
       input = input.to_s unless input.is_a?(String)
-      parts = input.split('.')
+      parts = input.split('.', -1)
       parts.map! do |part|
         if part =~ /^#{ACE_PREFIX}(.+)/
           begin


### PR DESCRIPTION
## Summary

Retain empty trailing labels when pure Ruby IDNA splits and rejoins domain names. The native implementation already retains them. This preserves fully qualified names through direct IDNA conversion without changing URI normalization's separate trailing-dot policy.

## Reproduction

```ruby
require 'addressable'
p Addressable::IDNA.to_ascii('bücher.example.')
p Addressable::IDNA.to_unicode('xn--bcher-kva.example.')
# Before: final dot lost in both; after: final dot retained
```

## Verification

- Ruby 4.0.6 through rbenv; existing suite: **1,433 examples / 0 failures / 5 existing pending** with pure Ruby IDNA, **1,466 examples / 0 failures / 5 existing pending** with idn-ruby 0.1.5 + libidn.
- 36 focused external assertions pass on this individual patch; the combined installed-release branch also passes all focused cases and both existing suites.
- Comparative RuboCop Lint: 15 existing offenses before and after; no new offense (line references move). Syntax and git diff --check pass.

## Compatibility and limitations

Direct pure-Ruby IDNA conversion now preserves trailing dots. URI#normalized_host still applies its existing normalization rule. No Unicode table update or IDNA version change.

No dependency/version/data updates. No repository tests were added or changed: the commissioning repository explicitly prohibits new/modified tests, so reproduction checks run outside this repository. Other Ruby versions/platforms were not run locally; upstream CI may require maintainer approval. The existing normalization proposal #589 and IDNA2008 proposal #496 are separate and unchanged.
