### PR TITLE
Preserve absent hosts when building display URIs

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -2200,7 +2200,7 @@ module Addressable
     # @return [Addressable::URI] A URI suitable for display purposes.
     def display_uri
       display_uri = self.normalize
-      display_uri.host = ::Addressable::IDNA.to_unicode(display_uri.host)
+      display_uri.host = ::Addressable::IDNA.to_unicode(display_uri.host) if display_uri.host
       return display_uri
     end
 


### PR DESCRIPTION
## Summary

Only convert a display URI's host when it exists. Passing nil through IDNA produces an empty string, inventing an authority and either raising or changing relative/opaque URIs.

## Reproduction

```ruby
require 'addressable'
p Addressable::URI.parse('abc').display_uri.to_s
# Before: InvalidURIError; after: abc
```

## Verification

- Ruby 4.0.6 through rbenv; existing suite: **1,433 examples / 0 failures / 5 existing pending** with pure Ruby IDNA, **1,466 examples / 0 failures / 5 existing pending** with idn-ruby 0.1.5 + libidn.
- 13 focused external assertions pass on this individual patch; the combined installed-release branch also passes all focused cases and both existing suites.
- Comparative RuboCop Lint: 15 existing offenses before and after; no new offense (line references move). Syntax and git diff --check pass.

## Compatibility and limitations

No intended breaking change. Relative and opaque URIs preserve an absent host. Existing host conversion remains unchanged.

No dependency/version/data updates. No repository tests were added or changed: the commissioning repository explicitly prohibits new/modified tests, so reproduction checks run outside this repository. Other Ruby versions/platforms were not run locally; upstream CI may require maintainer approval. The existing normalization proposal #589 and IDNA2008 proposal #496 are separate and unchanged.
