### PR TITLE
Omit undefined URI template collection members

### DIFF
--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -705,7 +705,7 @@ module Addressable
         first_to_expand = vars.find { |varspec|
           _, name, _ =  *varspec.match(VARSPEC)
           value = mapping[name]
-          value != nil && value != {} && value != []
+          mapping.key?(name) && value != nil && value != {} && value != []
         }
 
         vars = [first_to_expand] + vars.reject {|varspec| varspec == first_to_expand}  if first_to_expand

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -704,8 +704,9 @@ module Addressable
         # slight reordering of the variables to produce a valid url.
         first_to_expand = vars.find { |varspec|
           _, name, _ =  *varspec.match(VARSPEC)
-          value = mapping[name]
-          mapping.key?(name) && value != nil && value != {} && value != []
+          mapping.key?(name) &&
+            (value = mapping[name]) != nil &&
+            value != {} && value != []
         }
 
         vars = [first_to_expand] + vars.reject {|varspec| varspec == first_to_expand}  if first_to_expand

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -760,6 +760,13 @@ module Addressable
       return_value = varlist.split(',').inject([]) do |acc, varspec|
         _, name, modifier = *varspec.match(VARSPEC)
         value = mapping[name]
+        value = if value.kind_of?(Hash)
+          value.reject { |_, member| member.nil? }
+        elsif value.respond_to?(:to_ary)
+          value.to_ary.reject { |member| member.nil? }
+        else
+          value
+        end
         unless value == nil || value == {} || value == []
           allow_reserved = %w(+ #).include?(operator)
           # Common primitives where the .to_s output is well-defined

--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -704,7 +704,8 @@ module Addressable
         # slight reordering of the variables to produce a valid url.
         first_to_expand = vars.find { |varspec|
           _, name, _ =  *varspec.match(VARSPEC)
-          mapping.key?(name) && !mapping[name].nil?
+          value = mapping[name]
+          value != nil && value != {} && value != []
         }
 
         vars = [first_to_expand] + vars.reject {|varspec| varspec == first_to_expand}  if first_to_expand
@@ -758,7 +759,7 @@ module Addressable
       return_value = varlist.split(',').inject([]) do |acc, varspec|
         _, name, modifier = *varspec.match(VARSPEC)
         value = mapping[name]
-        unless value == nil || value == {}
+        unless value == nil || value == {} || value == []
           allow_reserved = %w(+ #).include?(operator)
           # Common primitives where the .to_s output is well-defined
           if Numeric === value || Symbol === value ||


### PR DESCRIPTION
## Summary

Bring collection expansion in line with RFC 6570 undefined-value handling:

- omit empty list variables instead of emitting empty parameters or delimiters;
- omit nil list members and nil-valued associative members;
- own to_ary results before normalization so custom coercions are not mutated.

Partial query expansion also skips undefined collection values when choosing its first parameter.

## Verification

- Ruby 4.0.6 pure suite: 1,433 examples, zero failures, five existing pending.
- Native idn-ruby suite: 1,466 examples, zero failures, five existing pending.
- Focused collection expansion and ownership models pass in isolation and in the final release consumer.
- Template release and current matrix: 1,585 cases, zero semantic differences or nonmatches outside the intended undefined-member corrections.
- Syntax and git diff checks pass.

## Compatibility and limitations

Empty arrays and nil members now remain undefined instead of producing empty output. Explicit empty strings remain defined. No dependency, version or Unicode-data updates are included.

No repository tests were added or changed under the commissioning repository no-test constraint; focused checks run externally. Other Ruby versions and platforms remain upstream CI limits.