### PR TITLE
Reuse the template match when extracting captures

### DIFF
--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -420,8 +420,9 @@ module Addressable
       expansions, expansion_regexp =
         parse_template_pattern(pattern, processor)
 
-      return nil unless uri.to_str.match(expansion_regexp)
-      unparsed_values = uri.to_str.scan(expansion_regexp).flatten
+      matched = uri.to_str.match(expansion_regexp)
+      return nil unless matched
+      unparsed_values = matched.captures
 
       if uri.to_str == pattern
         return Addressable::Template::MatchData.new(uri, self, mapping)


### PR DESCRIPTION
## Summary

Use the MatchData from the first anchored template match to extract captures, avoiding a duplicate regex scan and flatten allocation.

## Reproduction

```ruby
require 'addressable'
template = Addressable::Template.new('https://example.com/{path}{?a,b}')
uri = Addressable::URI.parse('https://example.com/hello?a=1&b=2')
p template.extract(uri)
# Same mapping before and after; one match instead of match + scan
```

## Verification

- Ruby 4.0.6 through rbenv; existing suite: **1,433 examples / 0 failures / 5 existing pending** with pure Ruby IDNA, **1,466 examples / 0 failures / 5 existing pending** with idn-ruby 0.1.5 + libidn.
- 6 focused external assertions pass on this individual patch; the combined installed-release branch also passes all focused cases and both existing suites.
- Comparative RuboCop Lint: 15 existing offenses before and after; no new offense (line references move). Syntax and git diff --check pass.

## Compatibility and limitations

No intended breaking change. Existing matching semantics, processors and capture order are preserved. Bounded 1,000-match check: 216,018 → 210,018 allocations. Timings 0.02329s → 0.02278s are too close to support a broad speed claim.

No dependency/version/data updates. No repository tests were added or changed: the commissioning repository explicitly prohibits new/modified tests, so reproduction checks run outside this repository. Other Ruby versions/platforms were not run locally; upstream CI may require maintainer approval. The existing normalization proposal #589 and IDNA2008 proposal #496 are separate and unchanged.
