### PR TITLE
Invalidate URI caches after component changes

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -928,6 +928,11 @@ module Addressable
 
       # Reset dependent values
       @normalized_scheme = NONE
+      @normalized_user = NONE
+      @normalized_password = NONE
+      @normalized_userinfo = NONE
+      @normalized_port = NONE
+      @normalized_path = nil
       remove_composite_values
 
       # Ensure we haven't created an invalid URI
@@ -983,6 +988,7 @@ module Addressable
       @normalized_userinfo = NONE
       @authority = nil
       @normalized_user = NONE
+      @normalized_password = NONE
       remove_composite_values
 
       # Ensure we haven't created an invalid URI
@@ -1038,6 +1044,7 @@ module Addressable
       @normalized_userinfo = NONE
       @authority = nil
       @normalized_password = NONE
+      @normalized_user = NONE
       remove_composite_values
 
       # Ensure we haven't created an invalid URI
@@ -2552,6 +2559,9 @@ module Addressable
     def remove_composite_values
       @uri_string = nil
       @hash = nil
+      @site = nil
+      @normalized_site = nil
+      @normalized_authority = nil
     end
 
     ##
@@ -2571,6 +2581,8 @@ module Addressable
     #
     # @api private
     def reset_ivs
+      @site = nil
+      @normalized_site = nil
       @scheme = nil
       @user = nil
       @normalized_scheme = NONE


### PR DESCRIPTION
## Summary

Invalidate dependent normalization and composite caches when URI components change. Host changes could retain an old normalized authority; scheme changes could retain an old default-port decision. Reset site caches during destructive replacement too, preserving sentinel-based instance variables from #486.

## Reproduction

```ruby
require 'addressable'
uri = Addressable::URI.parse('https://one.example')
uri.normalize
uri.host = 'two.example'
p uri.normalize.to_s
# Before: https://one.example/; after: https://two.example/
```

## Verification

- Ruby 4.0.6 through rbenv; existing suite: **1,433 examples / 0 failures / 5 existing pending** with pure Ruby IDNA, **1,466 examples / 0 failures / 5 existing pending** with idn-ruby 0.1.5 + libidn.
- 285 focused external assertions pass on this individual patch; the combined installed-release branch also passes all focused cases and both existing suites.
- Comparative RuboCop Lint: 15 existing offenses before and after; no new offense (line references move). Syntax and git diff --check pass.

## Compatibility and limitations

No intended breaking change. Corrects stale results after setters/merge!/join!/normalize!. Caches remain lazy; component strings and normalization rules are unchanged. This does not make externally mutated component strings safe or make URI instances thread-safe.

No dependency/version/data updates. No repository tests were added or changed: the commissioning repository explicitly prohibits new/modified tests, so reproduction checks run outside this repository. Other Ruby versions/platforms were not run locally; upstream CI may require maintainer approval. The existing normalization proposal #589 and IDNA2008 proposal #496 are separate and unchanged.
