### PR TITLE
Reject non-alphanumeric Punycode digits

### DIFF
--- a/lib/addressable/idna/pure.rb
+++ b/lib/addressable/idna/pure.rb
@@ -4677,11 +4677,11 @@ module Addressable
     # (for use in representing integers) in the range 0 to
     # base - 1, or PUNYCODE_BASE if codepoint does not represent a value.
     def self.punycode_decode_digit(codepoint)
-      if codepoint - 48 < 10
+      if codepoint >= 48 && codepoint <= 57
         codepoint - 22
-      elsif codepoint - 65 < 26
+      elsif codepoint >= 65 && codepoint <= 90
         codepoint - 65
-      elsif codepoint - 97 < 26
+      elsif codepoint >= 97 && codepoint <= 122
         codepoint - 97
       else
         PUNYCODE_BASE


### PR DESCRIPTION
## Summary

Require both lower and upper ASCII bounds when decoding Punycode digits. The prior subtraction checks accepted punctuation below each alphabet's lower bound and could turn malformed ACE labels into unrelated characters. Existing to_unicode bad-input fallback preserves the original label.

## Reproduction

```ruby
require 'addressable'
p Addressable::IDNA.to_unicode('xn--:')
# Before: y; after: xn--:
```

## Verification

- Ruby 4.0.6 through rbenv; existing suite: **1,433 examples / 0 failures / 5 existing pending** with pure Ruby IDNA, **1,466 examples / 0 failures / 5 existing pending** with idn-ruby 0.1.5 + libidn.
- 132 focused external assertions pass on this individual patch; the combined installed-release branch also passes all focused cases and both existing suites.
- Comparative RuboCop Lint: 15 existing offenses before and after; no new offense (line references move). Syntax and git diff --check pass.

## Compatibility and limitations

Malformed non-alphanumeric Punycode digits are now rejected by the private decoder; public to_unicode keeps those labels unchanged. Valid numeric, uppercase and lowercase digits retain their values. This is a parsing correctness fix, not a claim about broader IDNA validation.

No dependency/version/data updates. No repository tests were added or changed: the commissioning repository explicitly prohibits new/modified tests, so reproduction checks run outside this repository. Other Ruby versions/platforms were not run locally; upstream CI may require maintainer approval. The existing normalization proposal #589 and IDNA2008 proposal #496 are separate and unchanged.
