### PR TITLE
Preserve nested URI validation deferral

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -2394,13 +2394,14 @@ module Addressable
     # @param [Proc] block
     #   A set of operations to perform on a given URI.
     def defer_validation
+      validation_was_deferred = !!@validation_deferred
       raise LocalJumpError, "No block given." unless block_given?
       @validation_deferred = true
       yield
-      @validation_deferred = false
-      validate
+      @validation_deferred = validation_was_deferred
+      validate unless validation_was_deferred
     ensure
-      @validation_deferred = false
+      @validation_deferred = validation_was_deferred
     end
 
     def encode_with(coder)


### PR DESCRIPTION
Preserve the pre-existing validation deferral state so an inner defer_validation block cannot re-enable validation while its outer block is still composing a URI.

Verification: pure and native suites pass; focused nested-state model, URI suite, syntax and diff checks pass. Source-only patch; no tests included.