### PR TITLE
Parse assigned origins without losing IPv6 hosts

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -1336,15 +1336,20 @@ module Addressable
           raise TypeError, "Can't convert #{new_origin.class} into String."
         end
         new_origin = new_origin.to_str
-        new_scheme = new_origin[/^([^:\/?#]+):\/\//, 1]
-        unless new_scheme
+        origin_match = new_origin.match(
+          /\A([^:\/?#]+):\/\/(\[[^\]]+\]|[^\/?#:@]+)(?::([^\/?#]+))?\z/
+        )
+        unless new_origin.match?(/\A[^:\/?#]+:\/\//)
           raise InvalidURIError, 'An origin cannot omit the scheme.'
         end
-        new_host = new_origin[/:\/\/([^\/?#:]+)/, 1]
-        unless new_host
-          raise InvalidURIError, 'An origin cannot omit the host.'
+        unless origin_match
+          if new_origin.match?(/\A[^:\/?#]+:\/\/\z/)
+            raise InvalidURIError, 'An origin cannot omit the host.'
+          end
+          raise InvalidURIError,
+            'An origin cannot include userinfo, a path, query, or fragment.'
         end
-        new_port = new_origin[/:([^:@\[\]\/]*?)$/, 1]
+        new_scheme, new_host, new_port = origin_match.captures
       end
 
       self.scheme = new_scheme


### PR DESCRIPTION
Parse origin assignments as strict scheme and authority values: accept bracketed IPv6 hosts and reject userinfo, path, query or fragment instead of silently discarding or corrupting them. This addresses the origin subset of #272 without claiming its broader API scope.

Verification: pure and native suites pass; focused origin matrix, URI suite, syntax and diff checks pass. Source-only patch; no tests included.