### PR TITLE
Give URI clones independent string state

### DIFF
--- a/lib/addressable/uri.rb
+++ b/lib/addressable/uri.rb
@@ -2566,6 +2566,14 @@ module Addressable
 
     private
 
+    def initialize_copy(other)
+      super
+      instance_variables.each do |ivar|
+        value = instance_variable_get(ivar)
+        instance_variable_set(ivar, value.dup) if value.kind_of?(String)
+      end
+    end
+
     ##
     # Resets instance variables
     #


### PR DESCRIPTION
Duplicate every String-backed URI component during initialize_copy so mutating a clone cannot alter the original through shared component objects.

Verification: pure and native suites pass; focused clone and mutation matrix, URI suite, syntax and diff checks pass. Source-only patch; no tests included.