### PR TITLE
Enforce RFC 6570 prefix modifier bounds

### DIFF
--- a/lib/addressable/template.rb
+++ b/lib/addressable/template.rb
@@ -48,7 +48,7 @@ module Addressable
     variable =
       "(?:#{var_char}(?:\\.?#{var_char})*)"
     varspec =
-      "(?:(#{variable})(\\*|:\\d+)?)"
+      "(?:(#{variable})(\\*|:[1-9]\\d{0,3})?)"
     VARNAME =
       /^#{variable}$/
     VARSPEC =


### PR DESCRIPTION
Enforce RFC 6570 prefix modifiers as 1 through 9999 with no leading zero, rejecting forms the current grammar accepts outside that range.

Verification: pure and native suites pass; focused template grammar matrix, template suite, bounded adversarial matching and diff checks pass. Source-only patch; no tests included.