### PR TITLE
Keep malformed Punycode decoding non-raising

### DIFF
--- a/lib/addressable/idna/pure.rb
+++ b/lib/addressable/idna/pure.rb
@@ -92,7 +92,10 @@ module Addressable
         if part =~ /^#{ACE_PREFIX}(.+)/
           begin
             punycode_decode(part[/^#{ACE_PREFIX}(.+)/, 1])
-          rescue Addressable::IDNA::PunycodeBadInput
+          rescue Addressable::IDNA::PunycodeBadInput,
+                 Addressable::IDNA::PunycodeBigOutput,
+                 Addressable::IDNA::PunycodeOverflow,
+                 RangeError
             # toUnicode is explicitly defined as never-fails by the spec
             part
           end


### PR DESCRIPTION
Honor RFC 3490 toUnicode never-fail behavior for oversized, overflowing and invalid-scalar Punycode by returning the original label instead of raising.

Verification: pure 1,433 and native 1,466 example suites pass; focused IDNA model and 34-example IDNA suite pass; syntax and diff checks pass. Source-only patch; no tests included.